### PR TITLE
Added redis authentication with username

### DIFF
--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -262,6 +262,7 @@ broadcast-received-log-entries: true
 redis:
   enabled: false
   address: localhost
+  username: ''
   password: ''
 
 # Settings for RabbitMQ.

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -260,6 +260,7 @@ broadcast-received-log-entries: false
 redis:
   enabled: false
   address: localhost
+  username: ''
   password: ''
 
 # Settings for RabbitMQ.

--- a/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
@@ -631,7 +631,12 @@ public final class ConfigKeys {
      * The address of the redis server
      */
     public static final ConfigKey<String> REDIS_ADDRESS = notReloadable(stringKey("redis.address", null));
-
+    
+    /**
+     * The username to connect with, or an empty string if it should use default
+     */
+    public static final ConfigKey<String> REDIS_USERNAME = notReloadable(stringKey("redis.username", ""));
+    
     /**
      * The password in use by the redis server, or an empty string if there is no password
      */

--- a/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
@@ -631,12 +631,12 @@ public final class ConfigKeys {
      * The address of the redis server
      */
     public static final ConfigKey<String> REDIS_ADDRESS = notReloadable(stringKey("redis.address", null));
-    
+
     /**
      * The username to connect with, or an empty string if it should use default
      */
     public static final ConfigKey<String> REDIS_USERNAME = notReloadable(stringKey("redis.username", ""));
-    
+
     /**
      * The password in use by the redis server, or an empty string if there is no password
      */

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
@@ -140,13 +140,17 @@ public class MessagingFactory<P extends LuckPermsPlugin> {
 
             LuckPermsConfiguration config = getPlugin().getConfiguration();
             String address = config.get(ConfigKeys.REDIS_ADDRESS);
+            String username = config.get(ConfigKeys.REDIS_USERNAME);
             String password = config.get(ConfigKeys.REDIS_PASSWORD);
             if (password.isEmpty()) {
                 password = null;
             }
+            if (username.isEmpty()) {
+                username = null;
+            }
             boolean ssl = config.get(ConfigKeys.REDIS_SSL);
 
-            redis.init(address, password, ssl);
+            redis.init(address, username, password, ssl);
             return redis;
         }
     }

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
@@ -35,11 +35,9 @@ import me.lucko.luckperms.common.storage.implementation.StorageImplementation;
 import me.lucko.luckperms.common.storage.implementation.sql.SqlStorage;
 import me.lucko.luckperms.common.storage.implementation.sql.connection.hikari.MariaDbConnectionFactory;
 import me.lucko.luckperms.common.storage.implementation.sql.connection.hikari.MySqlConnectionFactory;
-
 import net.luckperms.api.messenger.IncomingMessageConsumer;
 import net.luckperms.api.messenger.Messenger;
 import net.luckperms.api.messenger.MessengerProvider;
-
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Locale;

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
@@ -35,9 +35,11 @@ import me.lucko.luckperms.common.storage.implementation.StorageImplementation;
 import me.lucko.luckperms.common.storage.implementation.sql.SqlStorage;
 import me.lucko.luckperms.common.storage.implementation.sql.connection.hikari.MariaDbConnectionFactory;
 import me.lucko.luckperms.common.storage.implementation.sql.connection.hikari.MySqlConnectionFactory;
+
 import net.luckperms.api.messenger.IncomingMessageConsumer;
 import net.luckperms.api.messenger.Messenger;
 import net.luckperms.api.messenger.MessengerProvider;
+
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Locale;

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/redis/RedisMessenger.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/redis/RedisMessenger.java
@@ -26,11 +26,18 @@
 package me.lucko.luckperms.common.messaging.redis;
 
 import me.lucko.luckperms.common.plugin.LuckPermsPlugin;
+
 import net.luckperms.api.messenger.IncomingMessageConsumer;
 import net.luckperms.api.messenger.Messenger;
 import net.luckperms.api.messenger.message.OutgoingMessage;
+
 import org.checkerframework.checker.nullness.qual.NonNull;
-import redis.clients.jedis.*;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.JedisPubSub;
+import redis.clients.jedis.Protocol;
 
 /**
  * An implementation of {@link Messenger} using Redis.

--- a/fabric/src/main/resources/luckperms.conf
+++ b/fabric/src/main/resources/luckperms.conf
@@ -265,6 +265,7 @@ broadcast-received-log-entries = true
 redis {
   enabled = false
   address = "localhost"
+  username = ""
   password = ""
 }
 

--- a/nukkit/src/main/resources/config.yml
+++ b/nukkit/src/main/resources/config.yml
@@ -257,6 +257,7 @@ broadcast-received-log-entries: true
 redis:
   enabled: false
   address: localhost
+  username: ''
   password: ''
 
 # Settings for RabbitMQ.

--- a/sponge/src/main/resources/luckperms.conf
+++ b/sponge/src/main/resources/luckperms.conf
@@ -265,6 +265,7 @@ broadcast-received-log-entries = true
 redis {
   enabled = false
   address = "localhost"
+  username = ""
   password = ""
 }
 

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -251,6 +251,7 @@ broadcast-received-log-entries: false
 redis:
   enabled: false
   address: localhost
+  username: ''
   password: ''
 
 # Settings for RabbitMQ.


### PR DESCRIPTION
Hi!
I'm going straight to the point: the current version of LuckPerms has just a password field for Redis authentication which limits the setup to a default username auth system which not always is the best option for security purposes. Then I decided to open this pull request to implement an optional username field which enables the authentication through username too. I have tried the new feature before opening this PR to test it and everything seems working correctly.