### PR TITLE
Added full support for tansient permissions through Vault API

### DIFF
--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/vault/AbstractVaultPermission.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/vault/AbstractVaultPermission.java
@@ -215,42 +215,56 @@ public abstract class AbstractVaultPermission extends Permission {
     }
 
     @Override
-    public final boolean playerAddTransient(Player player, String permission){
+    public boolean playerAddTransient(OfflinePlayer player, String permission) {
+        Objects.requireNonNull(player, "player");
+        Objects.requireNonNull(permission, "permission");
+        return userAddTransient(null, player.getUniqueId(), permission);
+    }
+
+    @Override
+    public final boolean playerAddTransient(Player player, String permission) {
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(permission, "permission");
         return userAddTransient(convertWorld(player), player.getUniqueId(), permission);
     }
-    
+
     @Override
-    public final boolean playerAddTransient(String world, OfflinePlayer player, String permission){
+    public final boolean playerAddTransient(String world, OfflinePlayer player, String permission) {
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(permission, "permission");
         return userAddTransient(convertWorld(world), player.getUniqueId(), permission);
     }
 
     @Override
-    public final boolean playerAddTransient(String world, Player player, String permission){
+    public final boolean playerAddTransient(String world, Player player, String permission) {
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(permission, "permission");
         return userAddTransient(convertWorld(world), player.getUniqueId(), permission);
     }
-    
+
     @Override
-    public final boolean playerRemoveTransient(Player player, String permission){
+    public boolean playerRemoveTransient(OfflinePlayer player, String permission) {
+        Objects.requireNonNull(player, "player");
+        Objects.requireNonNull(permission, "permission");
+        return userRemoveTransient(null, player.getUniqueId(), permission);
+    }
+
+    @Override
+    public final boolean playerRemoveTransient(Player player, String permission) {
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(permission, "permission");
         return userRemoveTransient(convertWorld(player), player.getUniqueId(), permission);
     }
-    
+
     @Override
-    public final boolean playerRemoveTransient(String world, OfflinePlayer player, String permission){
+    public final boolean playerRemoveTransient(String world, OfflinePlayer player, String permission) {
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(permission, "permission");
         return userRemoveTransient(convertWorld(world), player.getUniqueId(), permission);
     }
 
     @Override
-    public final boolean playerRemoveTransient(String world, Player player, String permission){
+    public final boolean playerRemoveTransient(String world, Player player, String permission) {
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(permission, "permission");
         return userRemoveTransient(convertWorld(world), player.getUniqueId(), permission);

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/vault/AbstractVaultPermission.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/vault/AbstractVaultPermission.java
@@ -183,7 +183,7 @@ public abstract class AbstractVaultPermission extends Permission {
     public final boolean playerAdd(Player player, String permission) {
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(permission, "permission");
-        return userAddPermission(convertWorld(player), ((OfflinePlayer) player).getUniqueId(), permission);
+        return userAddPermission(convertWorld(player), player.getUniqueId(), permission);
     }
 
     @Override
@@ -211,49 +211,49 @@ public abstract class AbstractVaultPermission extends Permission {
     public final boolean playerRemove(Player player, String permission) {
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(permission, "permission");
-        return userRemovePermission(convertWorld(player), ((OfflinePlayer) player).getUniqueId(), permission);
+        return userRemovePermission(convertWorld(player), player.getUniqueId(), permission);
     }
 
     @Override
     public final boolean playerAddTransient(Player player, String permission){
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(permission, "permission");
-        return userAddTransient(convertWorld(player), ((OfflinePlayer) player).getUniqueId(), permission);
+        return userAddTransient(convertWorld(player), player.getUniqueId(), permission);
     }
     
     @Override
     public final boolean playerAddTransient(String world, OfflinePlayer player, String permission){
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(permission, "permission");
-        return userAddTransient(convertWorld(world), ((OfflinePlayer) player).getUniqueId(), permission);
+        return userAddTransient(convertWorld(world), player.getUniqueId(), permission);
     }
 
     @Override
     public final boolean playerAddTransient(String world, Player player, String permission){
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(permission, "permission");
-        return userAddTransient(convertWorld(world), ((OfflinePlayer) player).getUniqueId(), permission);
+        return userAddTransient(convertWorld(world), player.getUniqueId(), permission);
     }
     
     @Override
     public final boolean playerRemoveTransient(Player player, String permission){
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(permission, "permission");
-        return userRemoveTransient(convertWorld(player), ((OfflinePlayer) player).getUniqueId(), permission);
+        return userRemoveTransient(convertWorld(player), player.getUniqueId(), permission);
     }
     
     @Override
     public final boolean playerRemoveTransient(String world, OfflinePlayer player, String permission){
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(permission, "permission");
-        return userRemoveTransient(convertWorld(world), ((OfflinePlayer) player).getUniqueId(), permission);
+        return userRemoveTransient(convertWorld(world), player.getUniqueId(), permission);
     }
 
     @Override
     public final boolean playerRemoveTransient(String world, Player player, String permission){
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(permission, "permission");
-        return userRemoveTransient(convertWorld(world), ((OfflinePlayer) player).getUniqueId(), permission);
+        return userRemoveTransient(convertWorld(world), player.getUniqueId(), permission);
     }
 
     @Override
@@ -323,7 +323,7 @@ public abstract class AbstractVaultPermission extends Permission {
     public final boolean playerInGroup(Player player, String group) {
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(group, "group");
-        return userInGroup(convertWorld(player), ((OfflinePlayer) player).getUniqueId(), group);
+        return userInGroup(convertWorld(player), player.getUniqueId(), group);
     }
 
     @Override
@@ -351,7 +351,7 @@ public abstract class AbstractVaultPermission extends Permission {
     public final boolean playerAddGroup(Player player, String group) {
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(group, "group");
-        return userAddGroup(convertWorld(player), ((OfflinePlayer) player).getUniqueId(), group);
+        return userAddGroup(convertWorld(player), player.getUniqueId(), group);
     }
 
     @Override
@@ -378,7 +378,7 @@ public abstract class AbstractVaultPermission extends Permission {
     @Override
     public final boolean playerRemoveGroup(Player player, String group) {
         Objects.requireNonNull(player, "player");
-        return userRemoveGroup(convertWorld(player), ((OfflinePlayer) player).getUniqueId(), group);
+        return userRemoveGroup(convertWorld(player), player.getUniqueId(), group);
     }
 
     @Override
@@ -402,7 +402,7 @@ public abstract class AbstractVaultPermission extends Permission {
     @Override
     public final String[] getPlayerGroups(Player player) {
         Objects.requireNonNull(player, "player");
-        return userGetGroups(convertWorld(player), ((OfflinePlayer) player).getUniqueId());
+        return userGetGroups(convertWorld(player), player.getUniqueId());
     }
 
     @Override
@@ -426,7 +426,7 @@ public abstract class AbstractVaultPermission extends Permission {
     @Override
     public final String getPrimaryGroup(Player player) {
         Objects.requireNonNull(player, "player");
-        return userGetPrimaryGroup(convertWorld(player), ((OfflinePlayer) player).getUniqueId());
+        return userGetPrimaryGroup(convertWorld(player), player.getUniqueId());
     }
 
 }

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/vault/AbstractVaultPermission.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/vault/AbstractVaultPermission.java
@@ -79,6 +79,8 @@ public abstract class AbstractVaultPermission extends Permission {
     public abstract boolean userHasPermission(String world, UUID uuid, String permission);
     public abstract boolean userAddPermission(String world, UUID uuid, String permission);
     public abstract boolean userRemovePermission(String world, UUID uuid, String permission);
+    public abstract boolean userAddTransient(String world, UUID uuid, String permission);
+    public abstract boolean userRemoveTransient(String world, UUID uuid, String permission);
     public abstract boolean userInGroup(String world, UUID uuid, String group);
     public abstract boolean userAddGroup(String world, UUID uuid, String group);
     public abstract boolean userRemoveGroup(String world, UUID uuid, String group);
@@ -210,6 +212,48 @@ public abstract class AbstractVaultPermission extends Permission {
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(permission, "permission");
         return userRemovePermission(convertWorld(player), ((OfflinePlayer) player).getUniqueId(), permission);
+    }
+
+    @Override
+    public final boolean playerAddTransient(Player player, String permission){
+        Objects.requireNonNull(player, "player");
+        Objects.requireNonNull(permission, "permission");
+        return userAddTransient(convertWorld(player), ((OfflinePlayer) player).getUniqueId(), permission);
+    }
+    
+    @Override
+    public final boolean playerAddTransient(String world, OfflinePlayer player, String permission){
+        Objects.requireNonNull(player, "player");
+        Objects.requireNonNull(permission, "permission");
+        return userAddTransient(convertWorld(world), ((OfflinePlayer) player).getUniqueId(), permission);
+    }
+
+    @Override
+    public final boolean playerAddTransient(String world, Player player, String permission){
+        Objects.requireNonNull(player, "player");
+        Objects.requireNonNull(permission, "permission");
+        return userAddTransient(convertWorld(world), ((OfflinePlayer) player).getUniqueId(), permission);
+    }
+    
+    @Override
+    public final boolean playerRemoveTransient(Player player, String permission){
+        Objects.requireNonNull(player, "player");
+        Objects.requireNonNull(permission, "permission");
+        return userRemoveTransient(convertWorld(player), ((OfflinePlayer) player).getUniqueId(), permission);
+    }
+    
+    @Override
+    public final boolean playerRemoveTransient(String world, OfflinePlayer player, String permission){
+        Objects.requireNonNull(player, "player");
+        Objects.requireNonNull(permission, "permission");
+        return userRemoveTransient(convertWorld(world), ((OfflinePlayer) player).getUniqueId(), permission);
+    }
+
+    @Override
+    public final boolean playerRemoveTransient(String world, Player player, String permission){
+        Objects.requireNonNull(player, "player");
+        Objects.requireNonNull(permission, "permission");
+        return userRemoveTransient(convertWorld(world), ((OfflinePlayer) player).getUniqueId(), permission);
     }
 
     @Override

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/vault/LuckPermsVaultPermission.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/vault/LuckPermsVaultPermission.java
@@ -187,7 +187,7 @@ public class LuckPermsVaultPermission extends AbstractVaultPermission {
         if (user instanceof Group) {
             throw new UnsupportedOperationException("Unable to modify the permissions of NPC players");
         }
-        return holderAddPermission(user, permission, world);
+        return holderAddPermission(user, permission, world, DataType.NORMAL);
     }
 
     @Override
@@ -199,7 +199,31 @@ public class LuckPermsVaultPermission extends AbstractVaultPermission {
         if (user instanceof Group) {
             throw new UnsupportedOperationException("Unable to modify the permissions of NPC players");
         }
-        return holderRemovePermission(user, permission, world);
+        return holderRemovePermission(user, permission, world, DataType.NORMAL);
+    }
+
+    @Override
+    public boolean userAddTransient(String world, UUID uuid, String permission) {
+        Objects.requireNonNull(uuid, "uuid");
+        Objects.requireNonNull(permission, "permission");
+
+        PermissionHolder user = lookupUser(uuid);
+        if (user instanceof Group) {
+            throw new UnsupportedOperationException("Unable to modify the permissions of NPC players");
+        }
+        return holderAddPermission(user, permission, world, DataType.TRANSIENT);
+    }
+
+    @Override
+    public boolean userRemoveTransient(String world, UUID uuid, String permission) {
+        Objects.requireNonNull(uuid, "uuid");
+        Objects.requireNonNull(permission, "permission");
+
+        PermissionHolder user = lookupUser(uuid);
+        if (user instanceof Group) {
+            throw new UnsupportedOperationException("Unable to modify the permissions of NPC players");
+        }
+        return holderRemovePermission(user, permission, world, DataType.TRANSIENT);
     }
 
     @Override
@@ -289,7 +313,7 @@ public class LuckPermsVaultPermission extends AbstractVaultPermission {
             return false;
         }
 
-        return holderAddPermission(group, permission, world);
+        return holderAddPermission(group, permission, world, DataType.NORMAL);
     }
 
     @Override
@@ -302,7 +326,7 @@ public class LuckPermsVaultPermission extends AbstractVaultPermission {
             return false;
         }
 
-        return holderRemovePermission(group, permission, world);
+        return holderRemovePermission(group, permission, world, DataType.NORMAL);
     }
 
     // utility methods for getting user and group instances
@@ -388,7 +412,7 @@ public class LuckPermsVaultPermission extends AbstractVaultPermission {
 
     // utility methods for modifying the state of PermissionHolders
 
-    private boolean holderAddPermission(PermissionHolder holder, String permission, String world) {
+    private boolean holderAddPermission(PermissionHolder holder, String permission, String world, DataType type) {
         Objects.requireNonNull(permission, "permission is null");
         Preconditions.checkArgument(!permission.isEmpty(), "permission is an empty string");
 
@@ -397,13 +421,13 @@ public class LuckPermsVaultPermission extends AbstractVaultPermission {
                 .withContext(DefaultContextKeys.WORLD_KEY, world == null ? "global" : world)
                 .build();
 
-        if (holder.setNode(DataType.NORMAL, node, true).wasSuccessful()) {
+        if (holder.setNode(type, node, true).wasSuccessful()) {
             return holderSave(holder);
         }
         return false;
     }
 
-    private boolean holderRemovePermission(PermissionHolder holder, String permission, String world) {
+    private boolean holderRemovePermission(PermissionHolder holder, String permission, String world, DataType type) {
         Objects.requireNonNull(permission, "permission is null");
         Preconditions.checkArgument(!permission.isEmpty(), "permission is an empty string");
 
@@ -412,7 +436,7 @@ public class LuckPermsVaultPermission extends AbstractVaultPermission {
                 .withContext(DefaultContextKeys.WORLD_KEY, world == null ? "global" : world)
                 .build();
 
-        if (holder.unsetNode(DataType.NORMAL, node).wasSuccessful()) {
+        if (holder.unsetNode(type, node).wasSuccessful()) {
             return holderSave(holder);
         }
         return false;
@@ -461,4 +485,5 @@ public class LuckPermsVaultPermission extends AbstractVaultPermission {
     private boolean useVaultServer() {
         return this.plugin.getConfiguration().get(ConfigKeys.USE_VAULT_SERVER);
     }
+
 }


### PR DESCRIPTION
As per this [issue](https://github.com/LuckPerms/LuckPerms/issues/3238) I have added the missing methods that the Vault API does wrong and implemented them to use the transient Node on the user's Permission Holder.