### PR TITLE
Add env variable option to read config

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/config/generic/adapter/ConfigurateConfigAdapter.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/generic/adapter/ConfigurateConfigAdapter.java
@@ -43,6 +43,7 @@ public abstract class ConfigurateConfigAdapter implements ConfigurationAdapter {
     private final LuckPermsPlugin plugin;
     private final Path path;
     private ConfigurationNode root;
+    private static final boolean SHOULD_READ_ENV = Boolean.getBoolean("luckperms.read-env");
 
     public ConfigurateConfigAdapter(LuckPermsPlugin plugin, Path path) {
         this.plugin = plugin;
@@ -72,17 +73,32 @@ public abstract class ConfigurateConfigAdapter implements ConfigurationAdapter {
 
     @Override
     public String getString(String path, String def) {
-        return resolvePath(path).getString(def);
+        String value = resolvePath(path).getString(def);
+
+        if (SHOULD_READ_ENV) {
+            return getEnvOrRead(path, value);
+        }
+        return value;
     }
 
     @Override
     public int getInteger(String path, int def) {
-        return resolvePath(path).getInt(def);
+        int value = resolvePath(path).getInt(def);
+
+        if (SHOULD_READ_ENV) {
+            return Integer.parseInt(getEnvOrRead(path, value));
+        }
+        return value;
     }
 
     @Override
     public boolean getBoolean(String path, boolean def) {
-        return resolvePath(path).getBoolean(def);
+        boolean value = resolvePath(path).getBoolean(def);
+
+        if (SHOULD_READ_ENV) {
+            return Boolean.parseBoolean(getEnvOrRead(path, value));
+        }
+        return value;
     }
 
     @Override
@@ -120,5 +136,9 @@ public abstract class ConfigurateConfigAdapter implements ConfigurationAdapter {
     @Override
     public LuckPermsPlugin getPlugin() {
         return this.plugin;
+    }
+
+    public String getEnvOrRead(String path, Object read) {
+        return System.getenv().getOrDefault(path, String.valueOf(read));
     }
 }

--- a/common/src/main/java/me/lucko/luckperms/common/config/generic/adapter/ConfigurateConfigAdapter.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/generic/adapter/ConfigurateConfigAdapter.java
@@ -139,6 +139,6 @@ public abstract class ConfigurateConfigAdapter implements ConfigurationAdapter {
     }
 
     public String getEnvOrRead(String path, Object read) {
-        return System.getenv().getOrDefault(path, String.valueOf(read));
+        return System.getenv().getOrDefault("LP_" + path.toUpperCase().replace(".", "_"), String.valueOf(read));
     }
 }


### PR DESCRIPTION
This pull request adds an option to allow the user to use System env / variable env with the config.
Like that people that use dynamic servers like with Kubernetes can instead of writing data to config use variable env to read it.

I actually put it on String, Integer, and Boolean since it's useless with map and list.
Also, people need to add -Dluckperms.read-env=true, if this is false, it will use the default behavior of config, instead, it will check if the variable is defined in the env, or will read the config if not.

Associated with [3294](https://github.com/LuckPerms/LuckPerms/issues/3294)