### PR TITLE
Optimize parent resolution in info commands

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/commands/group/GroupInfo.java
+++ b/common/src/main/java/me/lucko/luckperms/common/commands/group/GroupInfo.java
@@ -62,14 +62,11 @@ public class GroupInfo extends ChildCommand<Group> {
         Message.GROUP_INFO_GENERAL.send(sender, target.getName(), target.getPlainDisplayName(), target.getWeight());
 
         Map<Boolean, List<InheritanceNode>> parents = target.normalData().inheritanceAsSortedSet().stream()
-                                                            .filter(Node::getValue)
-                                                            .collect(Collectors.groupingBy(Node::hasExpiry,
-                                                                                           Collectors.toList()));
+                .filter(Node::getValue)
+                .collect(Collectors.groupingBy(Node::hasExpiry, Collectors.toList()));
 
-        List<InheritanceNode> temporaryParents = parents.getOrDefault(true,
-                                                                      Collections.emptyList());
-        List<InheritanceNode> permanentParents = parents.getOrDefault(false,
-                                                                      Collections.emptyList());
+        List<InheritanceNode> temporaryParents = parents.getOrDefault(true, Collections.emptyList());
+        List<InheritanceNode> permanentParents = parents.getOrDefault(false, Collections.emptyList());
 
         if (!permanentParents.isEmpty()) {
             Message.INFO_PARENT_HEADER.send(sender);

--- a/common/src/main/java/me/lucko/luckperms/common/commands/group/GroupInfo.java
+++ b/common/src/main/java/me/lucko/luckperms/common/commands/group/GroupInfo.java
@@ -42,6 +42,7 @@ import net.luckperms.api.node.Node;
 import net.luckperms.api.node.types.InheritanceNode;
 import net.luckperms.api.query.QueryOptions;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -60,26 +61,26 @@ public class GroupInfo extends ChildCommand<Group> {
 
         Message.GROUP_INFO_GENERAL.send(sender, target.getName(), target.getPlainDisplayName(), target.getWeight());
 
-        List<InheritanceNode> parents = target.normalData().inheritanceAsSortedSet().stream()
-                .filter(Node::getValue)
-                .filter(n -> !n.hasExpiry())
-                .collect(Collectors.toList());
+        Map<Boolean, List<InheritanceNode>> parents = target.normalData().inheritanceAsSortedSet().stream()
+                                                            .filter(Node::getValue)
+                                                            .collect(Collectors.groupingBy(Node::hasExpiry,
+                                                                                           Collectors.toList()));
 
-        List<InheritanceNode> tempParents = target.normalData().inheritanceAsSortedSet().stream()
-                .filter(Node::getValue)
-                .filter(Node::hasExpiry)
-                .collect(Collectors.toList());
+        List<InheritanceNode> temporaryParents = parents.getOrDefault(true,
+                                                                      Collections.emptyList());
+        List<InheritanceNode> permanentParents = parents.getOrDefault(false,
+                                                                      Collections.emptyList());
 
-        if (!parents.isEmpty()) {
+        if (!permanentParents.isEmpty()) {
             Message.INFO_PARENT_HEADER.send(sender);
-            for (InheritanceNode node : parents) {
+            for (InheritanceNode node : permanentParents) {
                 Message.INFO_PARENT_NODE_ENTRY.send(sender, node);
             }
         }
 
-        if (!tempParents.isEmpty()) {
+        if (!temporaryParents.isEmpty()) {
             Message.INFO_TEMP_PARENT_HEADER.send(sender);
-            for (InheritanceNode node : tempParents) {
+            for (InheritanceNode node : temporaryParents) {
                 Message.INFO_PARENT_TEMPORARY_NODE_ENTRY.send(sender, node);
             }
         }

--- a/common/src/main/java/me/lucko/luckperms/common/commands/user/UserInfo.java
+++ b/common/src/main/java/me/lucko/luckperms/common/commands/user/UserInfo.java
@@ -69,14 +69,11 @@ public class UserInfo extends ChildCommand<User> {
         );
 
         Map<Boolean, List<InheritanceNode>> parents = target.normalData().inheritanceAsSortedSet().stream()
-                                                            .filter(Node::getValue)
-                                                            .collect(Collectors.groupingBy(Node::hasExpiry,
-                                                                                           Collectors.toList()));
+                .filter(Node::getValue)
+                .collect(Collectors.groupingBy(Node::hasExpiry, Collectors.toList()));
 
-        List<InheritanceNode> temporaryParents = parents.getOrDefault(true,
-                                                                      Collections.emptyList());
-        List<InheritanceNode> permanentParents = parents.getOrDefault(false,
-                                                                      Collections.emptyList());
+        List<InheritanceNode> temporaryParents = parents.getOrDefault(true, Collections.emptyList());
+        List<InheritanceNode> permanentParents = parents.getOrDefault(false, Collections.emptyList());
 
         if (!permanentParents.isEmpty()) {
             Message.INFO_PARENT_HEADER.send(sender);

--- a/common/src/main/java/me/lucko/luckperms/common/commands/user/UserInfo.java
+++ b/common/src/main/java/me/lucko/luckperms/common/commands/user/UserInfo.java
@@ -44,6 +44,7 @@ import net.luckperms.api.node.Node;
 import net.luckperms.api.node.types.InheritanceNode;
 import net.luckperms.api.query.QueryOptions;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -67,26 +68,26 @@ public class UserInfo extends ChildCommand<User> {
                 plugin.getBootstrap().isPlayerOnline(target.getUniqueId())
         );
 
-        List<InheritanceNode> parents = target.normalData().inheritanceAsSortedSet().stream()
-                .filter(Node::getValue)
-                .filter(n -> !n.hasExpiry())
-                .collect(Collectors.toList());
+        Map<Boolean, List<InheritanceNode>> parents = target.normalData().inheritanceAsSortedSet().stream()
+                                                            .filter(Node::getValue)
+                                                            .collect(Collectors.groupingBy(Node::hasExpiry,
+                                                                                           Collectors.toList()));
 
-        List<InheritanceNode> tempParents = target.normalData().inheritanceAsSortedSet().stream()
-                .filter(Node::getValue)
-                .filter(Node::hasExpiry)
-                .collect(Collectors.toList());
+        List<InheritanceNode> temporaryParents = parents.getOrDefault(true,
+                                                                      Collections.emptyList());
+        List<InheritanceNode> permanentParents = parents.getOrDefault(false,
+                                                                      Collections.emptyList());
 
-        if (!parents.isEmpty()) {
+        if (!permanentParents.isEmpty()) {
             Message.INFO_PARENT_HEADER.send(sender);
-            for (InheritanceNode node : parents) {
+            for (InheritanceNode node : permanentParents) {
                 Message.INFO_PARENT_NODE_ENTRY.send(sender, node);
             }
         }
 
-        if (!tempParents.isEmpty()) {
+        if (!temporaryParents.isEmpty()) {
             Message.INFO_TEMP_PARENT_HEADER.send(sender);
-            for (InheritanceNode node : tempParents) {
+            for (InheritanceNode node : temporaryParents) {
                 Message.INFO_PARENT_TEMPORARY_NODE_ENTRY.send(sender, node);
             }
         }


### PR DESCRIPTION
Reworks the `GroupInfo` and `UserInfo` commands' method of resolving permanent and temporary parent nodes.

Uses Java 8's "Grouping By" collector to group the nodes into a map of results, rather than executing the entire operation twice with a different filter.


*(i would actually have loved to have this operation be generic and reusable outside of these commands, but I don't see where things like that are stored in the project, so duplicate code is fine for now ig)*