### PR TITLE
Use forge default resolver when result is undefined

### DIFF
--- a/forge/src/main/java/me/lucko/luckperms/forge/service/ForgePermissionHandler.java
+++ b/forge/src/main/java/me/lucko/luckperms/forge/service/ForgePermissionHandler.java
@@ -115,7 +115,9 @@ public class ForgePermissionHandler implements IPermissionHandler {
         if (node.getType() == PermissionTypes.BOOLEAN) {
             PermissionCache cache = user.getCachedData().getPermissionData(queryOptions);
             Tristate value = cache.checkPermission(node.getNodeName(), CheckOrigin.PLATFORM_API_HAS_PERMISSION).result();
-            return (T) (Boolean) value.asBoolean();
+            if (value != Tristate.UNDEFINED) {
+                return (T) (Boolean) value.asBoolean();
+            }
         }
 
         if (node.getType() == PermissionTypes.INTEGER) {


### PR DESCRIPTION
Current implementation never have a chance to use Forge's default resolver for BOOLEAN permissions and I guess it is not an intended behaviour.