### PR TITLE
Fix concurrent errors with unopenedURLs

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/plugin/classpath/URLClassLoaderAccess.java
+++ b/common/src/main/java/me/lucko/luckperms/common/plugin/classpath/URLClassLoaderAccess.java
@@ -167,8 +167,10 @@ public abstract class URLClassLoaderAccess {
                 URLClassLoaderAccess.throwError(new NullPointerException("unopenedURLs or pathURLs"));
             }
 
-            this.unopenedURLs.add(url);
-            this.pathURLs.add(url);
+            synchronized (this.unopenedURLs)  {
+                this.unopenedURLs.add(url);
+                this.pathURLs.add(url);
+            }
         }
     }
 


### PR DESCRIPTION
I had issues using ReflectionAppender with concurrency, so adding synchronized fixes it.