### PR TITLE
Fix forge capability not cloned when returning from the end

### DIFF
--- a/forge/src/main/java/me/lucko/luckperms/forge/capabilities/UserCapabilityListener.java
+++ b/forge/src/main/java/me/lucko/luckperms/forge/capabilities/UserCapabilityListener.java
@@ -58,10 +58,6 @@ public class UserCapabilityListener {
 
     @SubscribeEvent
     public void onPlayerClone(PlayerEvent.Clone event) {
-        if (!event.isWasDeath()) {
-            return;
-        }
-
         Player previousPlayer = event.getOriginal();
         Player currentPlayer = event.getPlayer();
 


### PR DESCRIPTION
Current implementation do not clone capability when teleport from the end to overworld with end portal, causing the capability not initialised:

<details>
<pre>
[13:17:39 ERROR]: Failed to handle packet net.minecraft.network.protocol.game.ServerboundClientCommandPacket@64b9ed37, suppressing error
java.lang.IllegalStateException: Capability has not been initialised
	at me.lucko.luckperms.forge.capabilities.UserCapabilityImpl.assertInitialised(UserCapabilityImpl.java:95) ~[?:?]
	at me.lucko.luckperms.forge.capabilities.UserCapabilityImpl.checkPermission(UserCapabilityImpl.java:101) ~[?:?]
	at me.lucko.luckperms.forge.util.BrigadierInjector$InjectedPermissionRequirement.test(BrigadierInjector.java:146) ~[?:?]
	at me.lucko.luckperms.forge.util.BrigadierInjector$InjectedPermissionRequirement.test(BrigadierInjector.java:131) ~[?:?]
	at com.mojang.brigadier.tree.CommandNode.canUse(CommandNode.java:65) ~[arclight-forge-1.18.2-1.0.7-SNAPSHOT.jar%231!/:?]
	at net.minecraftforge.server.command.CommandHelper.mergeCommandNode(CommandHelper.java:50) ~[forge-1.18.2-40.1.59-universal.jar%2383!/:?]
	at net.minecraft.commands.Commands.m_82095_(Commands.java:563) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.server.players.PlayerList.m_11226_(PlayerList.java:582) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.server.players.PlayerList.m_11289_(PlayerList.java:475) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.server.players.PlayerList.m_11236_(PlayerList.java:1367) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.m_6272_(ServerPlayNetHandlerMixin.java:1271) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.network.protocol.game.ServerboundClientCommandPacket.m_5797_(ServerboundClientCommandPacket.java:24) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.network.protocol.game.ServerboundClientCommandPacket.m_5797_(ServerboundClientCommandPacket.java:6) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.network.protocol.PacketUtils.md563ab7$lambda$ensureRunningOnSameThread$0$0(PacketThreadUtilMixin.java:537) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.server.TickTask.run(TickTask.java:18) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_6367_(BlockableEventLoop.java:157) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.m_6367_(ReentrantBlockableEventLoop.java:23) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.server.MinecraftServer.m_6367_(MinecraftServer.java:799) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.server.MinecraftServer.m_6367_(MinecraftServer.java:164) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_7245_(BlockableEventLoop.java:131) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.server.MinecraftServer.m_129961_(MinecraftServer.java:782) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.server.MinecraftServer.m_7245_(MinecraftServer.java:776) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_18701_(BlockableEventLoop.java:140) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.server.MinecraftServer.m_130012_(MinecraftServer.java:762) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:2139) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at net.minecraft.server.MinecraftServer.m_177918_(MinecraftServer.java:261) ~[server-1.18.2-20220404.173914-srg.jar%2378!/:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]
</pre>
</details>