### PR TITLE
Add nullcheck to UUIDs

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/plugin/util/AbstractConnectionListener.java
+++ b/common/src/main/java/me/lucko/luckperms/common/plugin/util/AbstractConnectionListener.java
@@ -27,7 +27,6 @@ package me.lucko.luckperms.common.plugin.util;
 
 import me.lucko.luckperms.common.model.User;
 import me.lucko.luckperms.common.plugin.LuckPermsPlugin;
-
 import net.luckperms.api.model.PlayerSaveResult;
 import net.luckperms.api.model.data.DataType;
 import net.luckperms.api.platform.Platform;
@@ -61,6 +60,11 @@ public abstract class AbstractConnectionListener {
     }
 
     public User loadUser(UUID uniqueId, String username) {
+        if (uniqueId == null) {
+            this.plugin.getLogger().severe("Attempted to load data for player '" + username + "' with a null UUID! This implies a plugin/mod/your server software is interfering with UUIDS.");
+            this.plugin.getLogger().severe("This is completely unsupported and **will not** work with LuckPerms.");
+            throw new NullPointerException("Attempted to load a user wih a null UUID.");
+        }
         final long startTime = System.currentTimeMillis();
 
         // register with the housekeeper to avoid accidental unloads


### PR DESCRIPTION
Adds a null check for UUIDs on join. Theoretically this shouldn't be possible, but some offline mode authentication plugins and server softwares with offline mode are...special. Adding an explicit check instead of waiting for it to eventually hit something that complains also lets us also have a friendlier error for the end user to read so they can (hopefully) self-diagnose,

I haven't tested the code besides ensuring it builds (partially because I'm not actually sure how to easily cause a null UUID), but I'd like to think I know how to write a null check without screwing up.