### PR TITLE
Restore offline mode support for Fabric servers

### DIFF
--- a/fabric/src/main/java/me/lucko/luckperms/fabric/listeners/FabricConnectionListener.java
+++ b/fabric/src/main/java/me/lucko/luckperms/fabric/listeners/FabricConnectionListener.java
@@ -46,6 +46,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerLoginNetworkHandler;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Uuids;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -69,7 +70,7 @@ public class FabricConnectionListener extends AbstractConnectionListener {
 
         // Get their profile from the net handler - it should have been initialised by now.
         GameProfile profile = ((ServerLoginNetworkHandlerAccessor) netHandler).getGameProfile();
-        UUID uniqueId = profile.getId();
+        UUID uniqueId = profile.isComplete() ? profile.getId() : Uuids.getOfflinePlayerUuid(profile.getName());
         String username = profile.getName();
 
         if (this.plugin.getConfiguration().get(ConfigKeys.DEBUG_LOGINS)) {


### PR DESCRIPTION
The offline profile is created inside the `ServerLoginNetworkHandler.acceptPlayer()` method, which is called after handling the Fabric's `ServerLoginConnectionEvents.QUERY_START` event.

Fixes #3564, fixes #3574, fixes #3573