### PR TITLE
Update mariadb jdbc driver to 3.1.2

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/dependencies/Dependency.java
+++ b/common/src/main/java/me/lucko/luckperms/common/dependencies/Dependency.java
@@ -141,8 +141,8 @@ public enum Dependency {
     MARIADB_DRIVER(
             "org{}mariadb{}jdbc",
             "mariadb-java-client",
-            "2.7.2",
-            "o/Z3bfCELPZefxWFFQEtUwfalJ9mBCKC4e5EdN0Z9Eg=",
+            "3.1.3",
+            "ESl+5lYkJsScgTh8hgFTy8ExxMPQQkktT20tl6s6HKU=",
             Relocation.of("mariadb", "org{}mariadb{}jdbc")
     ),
     MYSQL_DRIVER(

--- a/common/src/main/java/me/lucko/luckperms/common/storage/implementation/sql/connection/hikari/HikariConnectionFactory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/storage/implementation/sql/connection/hikari/HikariConnectionFactory.java
@@ -37,8 +37,11 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 
 import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -240,6 +243,20 @@ public abstract class HikariConnectionFactory implements ConnectionFactory {
             }
 
             logger.warn("Class " + className + " has been loaded by: " + loaderName);
+        }
+    }
+
+    protected static void deregisterDriver(String driverClassName) {
+        Enumeration<Driver> drivers = DriverManager.getDrivers();
+        while (drivers.hasMoreElements()) {
+            Driver driver = drivers.nextElement();
+            if (driver.getClass().getName().equals(driverClassName)) {
+                try {
+                    DriverManager.deregisterDriver(driver);
+                } catch (SQLException e) {
+                    // ignore
+                }
+            }
         }
     }
 }

--- a/common/src/main/java/me/lucko/luckperms/common/storage/implementation/sql/connection/hikari/MariaDbConnectionFactory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/storage/implementation/sql/connection/hikari/MariaDbConnectionFactory.java
@@ -49,23 +49,20 @@ public class MariaDbConnectionFactory extends HikariConnectionFactory {
 
     @Override
     protected void configureDatabase(HikariConfig config, String address, String port, String databaseName, String username, String password) {
-        config.setDataSourceClassName("org.mariadb.jdbc.MariaDbDataSource");
-        config.addDataSourceProperty("serverName", address);
-        config.addDataSourceProperty("port", port);
-        config.addDataSourceProperty("databaseName", databaseName);
+        config.setDriverClassName("org.mariadb.jdbc.Driver");
+        config.setJdbcUrl("jdbc:mariadb://" + address + ":" + port + "/" + databaseName);
         config.setUsername(username);
         config.setPassword(password);
     }
 
     @Override
-    protected void setProperties(HikariConfig config, Map<String, Object> properties) {
-        String propertiesString = properties.entrySet().stream()
-                .map(e -> e.getKey() + "=" + e.getValue())
-                .collect(Collectors.joining(";"));
+    protected void postInitialize() {
+        super.postInitialize();
 
-        // kinda hacky. this will call #setProperties on the datasource, which will append these options
-        // onto the connections.
-        config.addDataSourceProperty("properties", propertiesString);
+        // Calling Class.forName("org.mariadb.jdbc.Driver") is enough to call the static initializer
+        // which makes our driver available in DriverManager. We don't want that, so unregister it after
+        // the pool has been setup.
+        deregisterDriver("org.mariadb.jdbc.Driver");
     }
 
     @Override

--- a/common/src/main/java/me/lucko/luckperms/common/storage/implementation/sql/connection/hikari/MySqlConnectionFactory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/storage/implementation/sql/connection/hikari/MySqlConnectionFactory.java
@@ -65,17 +65,7 @@ public class MySqlConnectionFactory extends HikariConnectionFactory {
         // Calling Class.forName("com.mysql.cj.jdbc.Driver") is enough to call the static initializer
         // which makes our driver available in DriverManager. We don't want that, so unregister it after
         // the pool has been setup.
-        Enumeration<Driver> drivers = DriverManager.getDrivers();
-        while (drivers.hasMoreElements()) {
-            Driver driver = drivers.nextElement();
-            if (driver.getClass().getName().equals("com.mysql.cj.jdbc.Driver")) {
-                try {
-                    DriverManager.deregisterDriver(driver);
-                } catch (SQLException e) {
-                    // ignore
-                }
-            }
-        }
+        deregisterDriver("com.mysql.cj.jdbc.Driver");
     }
 
     @Override

--- a/standalone/build.gradle
+++ b/standalone/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     testImplementation 'com.impossibl.pgjdbc-ng:pgjdbc-ng:0.8.9'
     testImplementation 'com.h2database:h2:2.1.214'
     testImplementation 'mysql:mysql-connector-java:8.0.23'
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:2.7.2'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.1.3'
     testImplementation 'org.mongodb:mongodb-driver-legacy:4.5.0'
     testImplementation 'me.lucko.configurate:configurate-toml:3.7'
     testImplementation 'org.spongepowered:configurate-hocon:3.7.2'

--- a/standalone/src/test/java/me/lucko/luckperms/standalone/MessagingIntegrationTest.java
+++ b/standalone/src/test/java/me/lucko/luckperms/standalone/MessagingIntegrationTest.java
@@ -82,7 +82,7 @@ public class MessagingIntegrationTest {
     }
 
     @Nested
-    class Sql {
+    class MySql {
 
         @Container
         private final GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("mysql:8"))
@@ -102,6 +102,36 @@ public class MessagingIntegrationTest {
                     .put("data.address", host + ":" + port)
                     .put("data.database", "minecraft")
                     .put("data.username", "root")
+                    .put("data.password", "passw0rd")
+                    .build();
+
+            testMessaging(config, tempDirA, tempDirB);
+        }
+    }
+
+    @Nested
+    class MariaDb {
+
+        @Container
+        private final GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("mariadb"))
+                .withEnv("MARIADB_USER", "minecraft")
+                .withEnv("MARIADB_PASSWORD", "passw0rd")
+                .withEnv("MARIADB_ROOT_PASSWORD", "rootpassw0rd")
+                .withEnv("MARIADB_DATABASE", "minecraft")
+                .withExposedPorts(3306);
+
+        @Test
+        public void testMySql(@TempDir Path tempDirA, @TempDir Path tempDirB) throws InterruptedException {
+            assertTrue(this.container.isRunning());
+
+            String host = this.container.getHost();
+            Integer port = this.container.getFirstMappedPort();
+
+            Map<String, String> config = ImmutableMap.<String, String>builder()
+                    .put("storage-method", "mariadb")
+                    .put("data.address", host + ":" + port)
+                    .put("data.database", "minecraft")
+                    .put("data.username", "minecraft")
                     .put("data.password", "passw0rd")
                     .build();
 


### PR DESCRIPTION
In older versions of the driver (before 3.1.0?) there is a bug, in newer versions I have not noticed it
(litebans uses 3.0.7)

![image](https://user-images.githubusercontent.com/54859825/217333225-b24fc36e-cab8-4e9e-bcab-150e8a78e502.png)
![image](https://user-images.githubusercontent.com/54859825/217333246-bd07fb57-f3b9-4870-a4bb-af3a71010e52.png)
