### PR TITLE
Add date on hover to log

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/locale/Message.java
+++ b/common/src/main/java/me/lucko/luckperms/common/locale/Message.java
@@ -57,6 +57,8 @@ import net.luckperms.api.util.Tristate;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -89,6 +91,9 @@ import static net.kyori.adventure.text.format.TextDecoration.BOLD;
  * A collection of formatted messages used by the plugin.
  */
 public interface Message {
+
+    static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd '@' HH:mm:ss")
+            .withZone(ZoneId.systemDefault());
 
     TextComponent OPEN_BRACKET = Component.text('(');
     TextComponent CLOSE_BRACKET = Component.text(')');
@@ -3714,7 +3719,7 @@ public interface Message {
                                     .color(GRAY)
                                     .key("luckperms.duration.since")
                                     .args(DurationFormatter.CONCISE_LOW_ACCURACY.format(action.getDurationSince()))
-                                    .hoverEvent(HoverEvent.showText(text().append(text("Date: ", GRAY)).append(text(action.getTimestamp().toString(), AQUA))))
+                                    .hoverEvent(HoverEvent.showText(text().append(text("Date: ", GRAY)).append(text(DATE_FORMAT.format(action.getTimestamp()), AQUA))))
                             )
                             .append(CLOSE_BRACKET)
                     )

--- a/common/src/main/java/me/lucko/luckperms/common/locale/Message.java
+++ b/common/src/main/java/me/lucko/luckperms/common/locale/Message.java
@@ -3719,7 +3719,7 @@ public interface Message {
                                     .color(GRAY)
                                     .key("luckperms.duration.since")
                                     .args(DurationFormatter.CONCISE_LOW_ACCURACY.format(action.getDurationSince()))
-                                    .hoverEvent(HoverEvent.showText(text().append(text("Date: ", GRAY)).append(text(DATE_FORMAT.format(action.getTimestamp()), AQUA))))
+                                    .hoverEvent(HoverEvent.showText(text().append(translatable("luckperms.duration.date", GRAY)).append(text(": ", GRAY)).append(text(DATE_FORMAT.format(action.getTimestamp()), AQUA))))
                             )
                             .append(CLOSE_BRACKET)
                     )

--- a/common/src/main/java/me/lucko/luckperms/common/locale/Message.java
+++ b/common/src/main/java/me/lucko/luckperms/common/locale/Message.java
@@ -3714,6 +3714,7 @@ public interface Message {
                                     .color(GRAY)
                                     .key("luckperms.duration.since")
                                     .args(DurationFormatter.CONCISE_LOW_ACCURACY.format(action.getDurationSince()))
+                                    .hoverEvent(HoverEvent.showText(text().append(text("Date: ", GRAY)).append(text(action.getTimestamp().toString(), AQUA))))
                             )
                             .append(CLOSE_BRACKET)
                     )

--- a/common/src/main/resources/luckperms_en.properties
+++ b/common/src/main/resources/luckperms_en.properties
@@ -54,6 +54,7 @@ luckperms.duration.unit.seconds.plural={0} seconds
 luckperms.duration.unit.seconds.singular={0} second
 luckperms.duration.unit.seconds.short={0}s
 luckperms.duration.since={0} ago
+luckperms.duration.date=Date
 luckperms.command.misc.invalid-code=Invalid code
 luckperms.command.misc.response-code-key=response code
 luckperms.command.misc.error-message-key=message


### PR DESCRIPTION
This closes #3408.

On hover message on the currently displayed time since ago the full date and time is shown.
![image](https://user-images.githubusercontent.com/12849249/221313575-3ea2e6af-b939-406c-a3b8-699eb19ffa8f.png)

This is my first PR so please let me know if I have missed anything!