### PR TITLE
Add in paste to the tab completions for verbose

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/commands/misc/VerboseCommand.java
+++ b/common/src/main/java/me/lucko/luckperms/common/commands/misc/VerboseCommand.java
@@ -186,7 +186,7 @@ public class VerboseCommand extends SingleCommand {
     @Override
     public List<String> tabComplete(LuckPermsPlugin plugin, Sender sender, ArgumentList args) {
         return TabCompleter.create()
-                .at(0, CompletionSupplier.startsWith("on", "record", "off", "upload", "command"))
+                .at(0, CompletionSupplier.startsWith("on", "record", "off", "upload", "paste", "command"))
                 .complete(args);
     }
 }


### PR DESCRIPTION
This led to some confusion today on the docs and it was settled that it would be easiest to just add this in as a tab completion.