### PR TITLE
Fix player data being corrupted on respawn. (#3557, #3584, #3596)

### DIFF
--- a/forge/src/main/java/me/lucko/luckperms/forge/capabilities/UserCapabilityListener.java
+++ b/forge/src/main/java/me/lucko/luckperms/forge/capabilities/UserCapabilityListener.java
@@ -68,6 +68,8 @@ public class UserCapabilityListener {
 
             current.initialise(previous);
             current.getQueryOptionsCache().invalidate();
+        } catch (IllegalStateException e) {
+            // continue on if we cannot copy original data
         } finally {
             previousPlayer.invalidateCaps();
         }


### PR DESCRIPTION
This PR addresses player data being corrupted if exception was thrown during `PlayerEvent.Clone`.