### PR TITLE
Cleanup loaders on shutdown

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/dependencies/DependencyManager.java
+++ b/common/src/main/java/me/lucko/luckperms/common/dependencies/DependencyManager.java
@@ -57,7 +57,7 @@ import java.util.concurrent.Executor;
 /**
  * Loads and manages runtime dependencies for the plugin.
  */
-public class DependencyManager {
+public class DependencyManager implements AutoCloseable {
 
     /** A registry containing plugin specific behaviour for dependencies. */
     private final DependencyRegistry registry;
@@ -233,6 +233,27 @@ public class DependencyManager {
         }
 
         return cacheDirectory;
+    }
+
+    @Override
+    public void close() {
+        IOException firstEx = null;
+
+        for (IsolatedClassLoader loader : this.loaders.values()) {
+            try {
+                loader.close();
+            } catch (IOException ex) {
+                if (firstEx == null) {
+                    firstEx = ex;
+                } else {
+                    firstEx.addSuppressed(ex);
+                }
+            }
+        }
+
+        if (firstEx != null) {
+            firstEx.printStackTrace();
+        }
     }
 
 }

--- a/common/src/main/java/me/lucko/luckperms/common/dependencies/relocation/RelocationHandler.java
+++ b/common/src/main/java/me/lucko/luckperms/common/dependencies/relocation/RelocationHandler.java
@@ -30,6 +30,7 @@ import me.lucko.luckperms.common.dependencies.DependencyManager;
 import me.lucko.luckperms.common.dependencies.classloader.IsolatedClassLoader;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
@@ -51,11 +52,12 @@ public class RelocationHandler {
     private final Method jarRelocatorRunMethod;
 
     public RelocationHandler(DependencyManager dependencyManager) {
+        IsolatedClassLoader classLoader = null;
         try {
             // download the required dependencies for remapping
             dependencyManager.loadDependencies(DEPENDENCIES);
             // get a classloader containing the required dependencies as sources
-            IsolatedClassLoader classLoader = dependencyManager.obtainClassLoaderWith(DEPENDENCIES);
+            classLoader = dependencyManager.obtainClassLoaderWith(DEPENDENCIES);
 
             // load the relocator class
             Class<?> jarRelocatorClass = classLoader.loadClass(JAR_RELOCATOR_CLASS);
@@ -67,6 +69,14 @@ public class RelocationHandler {
             this.jarRelocatorRunMethod = jarRelocatorClass.getDeclaredMethod(JAR_RELOCATOR_RUN_METHOD);
             this.jarRelocatorRunMethod.setAccessible(true);
         } catch (Exception e) {
+            try {
+                if (classLoader != null) {
+                    classLoader.close();
+                }
+            } catch (IOException ex) {
+                e.addSuppressed(ex);
+            }
+
             throw new RuntimeException(e);
         }
     }
@@ -81,4 +91,5 @@ public class RelocationHandler {
         Object relocator = this.jarRelocatorConstructor.newInstance(input.toFile(), output.toFile(), mappings);
         this.jarRelocatorRunMethod.invoke(relocator);
     }
+
 }

--- a/common/src/main/java/me/lucko/luckperms/common/plugin/AbstractLuckPermsPlugin.java
+++ b/common/src/main/java/me/lucko/luckperms/common/plugin/AbstractLuckPermsPlugin.java
@@ -292,6 +292,9 @@ public abstract class AbstractLuckPermsPlugin implements LuckPermsPlugin {
         this.httpClient.dispatcher().executorService().shutdown();
         this.httpClient.connectionPool().evictAll();
 
+        // close isolated loaders for non-relocated dependencies
+        getDependencyManager().close();
+
         // close classpath appender
         getBootstrap().getClassPathAppender().close();
 


### PR DESCRIPTION
Close the isolated loaders for dependencies that are not relocated (H2/SQLite drivers, ASM, JAR relocator etc) on disable.