### PR TITLE
fix race

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/treeview/TreeNode.java
+++ b/common/src/main/java/me/lucko/luckperms/common/treeview/TreeNode.java
@@ -83,10 +83,9 @@ public class TreeNode {
         return a;
     }
     public @Nullable TreeNode tryInsert(String s) {
-        Map<String, TreeNode> childMap = getChildMap();
-        if (!allowInsert(this)) {
+        if (!allowInsert(this))
             return null;
-        }
+        Map<String, TreeNode> childMap = getChildMap();
         return childMap.computeIfAbsent(s, x -> new TreeNode(this));
     }
 


### PR DESCRIPTION
when reading an object through a race, we are required to stretch two states - release / acquire

in this context, initialization does not go through a race, but through a synchronization block, but reading an object without synchronization is not valid in this case

two options:
add synchonized (blocking) to all methods everywhere - not the best option
and making the field volatile is a better option

But you can go further, creating CHM is a cheap operation, with low competition for this method it is better to do CAS in for-loopE, so we get much more performance