### PR TITLE
Add support for redis cluster

### DIFF
--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -261,11 +261,11 @@ push-log-entries: true
 broadcast-received-log-entries: true
 
 # Settings for Redis.
-# Port 6379 is used by default; paste the addresses of your nodes in the format "host:port" under addresses.
+# Port 6379 is used by default; set address to "host:port" if differs
+# Multiple Redis nodes can be specified in the same format as a string list under the name "addresses".
 redis:
   enabled: false
-  addresses:
-    - localhost
+  address: localhost
   username: ''
   password: ''
 

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -264,7 +264,8 @@ broadcast-received-log-entries: true
 # Port 6379 is used by default; set address to "host:port" if differs
 redis:
   enabled: false
-  address: localhost
+  addresses:
+    - localhost
   username: ''
   password: ''
 

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -261,7 +261,7 @@ push-log-entries: true
 broadcast-received-log-entries: true
 
 # Settings for Redis.
-# Port 6379 is used by default; set address to "host:port" if differs
+# Port 6379 is used by default; paste the addresses of your nodes in the format "host:port" under addresses.
 redis:
   enabled: false
   addresses:

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -259,7 +259,7 @@ push-log-entries: true
 broadcast-received-log-entries: false
 
 # Settings for Redis.
-# Port 6379 is used by default; set address to "host:port" if differs
+# Port 6379 is used by default; paste the addresses of your nodes in the format "host:port" under addresses.
 redis:
   enabled: false
   addresses:

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -259,11 +259,11 @@ push-log-entries: true
 broadcast-received-log-entries: false
 
 # Settings for Redis.
-# Port 6379 is used by default; paste the addresses of your nodes in the format "host:port" under addresses.
+# Port 6379 is used by default; set address to "host:port" if differs
+# Multiple Redis nodes can be specified in the same format as a string list under the name "addresses".
 redis:
   enabled: false
-  addresses:
-    - localhost
+  address: localhost
   username: ''
   password: ''
 

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -262,7 +262,8 @@ broadcast-received-log-entries: false
 # Port 6379 is used by default; set address to "host:port" if differs
 redis:
   enabled: false
-  address: localhost
+  addresses:
+    - localhost
   username: ''
   password: ''
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -74,7 +74,7 @@ dependencies {
         transitive = false
     }
     compileOnly 'com.zaxxer:HikariCP:4.0.3'
-    compileOnly 'redis.clients:jedis:4.4.2'
+    compileOnly 'redis.clients:jedis:4.4.3'
     compileOnly 'io.nats:jnats:2.16.4'
     compileOnly 'com.rabbitmq:amqp-client:5.12.0'
     compileOnly 'org.mongodb:mongodb-driver-legacy:4.5.0'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -74,7 +74,7 @@ dependencies {
         transitive = false
     }
     compileOnly 'com.zaxxer:HikariCP:4.0.3'
-    compileOnly 'redis.clients:jedis:3.5.2'
+    compileOnly 'redis.clients:jedis:4.4.2'
     compileOnly 'io.nats:jnats:2.16.4'
     compileOnly 'com.rabbitmq:amqp-client:5.12.0'
     compileOnly 'org.mongodb:mongodb-driver-legacy:4.5.0'

--- a/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
@@ -635,7 +635,7 @@ public final class ConfigKeys {
      * @deprecated The Config Key is only available for backwards compatibility. Please use {@link #REDIS_ADDRESSES}
      */
     @Deprecated
-    public static final ConfigKey<String> REDIS_ADDRESS = notReloadable(stringKey("redis.address", ""));
+    public static final ConfigKey<String> REDIS_ADDRESS = notReloadable(stringKey("redis.address", null));
 
     /**
      * The addresses of the redis servers

--- a/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
@@ -31,7 +31,6 @@ import com.google.common.collect.Maps;
 import me.lucko.luckperms.common.cacheddata.type.SimpleMetaValueSelector;
 import me.lucko.luckperms.common.config.generic.KeyedConfiguration;
 import me.lucko.luckperms.common.config.generic.key.ConfigKey;
-import static me.lucko.luckperms.common.config.generic.key.ConfigKeyFactory.*;
 import me.lucko.luckperms.common.config.generic.key.SimpleConfigKey;
 import me.lucko.luckperms.common.context.calculator.WorldNameRewriter;
 import me.lucko.luckperms.common.graph.TraversalAlgorithm;
@@ -67,6 +66,8 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+
+import static me.lucko.luckperms.common.config.generic.key.ConfigKeyFactory.*;
 
 /**
  * All of the {@link ConfigKey}s used by LuckPerms.

--- a/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
@@ -631,14 +631,11 @@ public final class ConfigKeys {
 
     /**
      * The address of the redis server
-     *
-     * @deprecated The Config Key is only available for backwards compatibility. Please use {@link #REDIS_ADDRESSES}
      */
-    @Deprecated
     public static final ConfigKey<String> REDIS_ADDRESS = notReloadable(stringKey("redis.address", null));
 
     /**
-     * The addresses of the redis servers
+     * The addresses of the redis servers (only for redis clusters)
      */
     public static final ConfigKey<List<String>> REDIS_ADDRESSES = notReloadable(stringListKey("redis.addresses", new ArrayList<>()));
 

--- a/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
@@ -28,7 +28,6 @@ package me.lucko.luckperms.common.config;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import java.util.Collections;
 import me.lucko.luckperms.common.cacheddata.type.SimpleMetaValueSelector;
 import me.lucko.luckperms.common.config.generic.KeyedConfiguration;
 import me.lucko.luckperms.common.config.generic.key.ConfigKey;

--- a/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
@@ -28,6 +28,7 @@ package me.lucko.luckperms.common.config;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import java.util.Collections;
 import me.lucko.luckperms.common.cacheddata.type.SimpleMetaValueSelector;
 import me.lucko.luckperms.common.config.generic.KeyedConfiguration;
 import me.lucko.luckperms.common.config.generic.key.ConfigKey;
@@ -631,8 +632,16 @@ public final class ConfigKeys {
 
     /**
      * The address of the redis server
+     *
+     * @deprecated use {@link #REDIS_ADDRESSES}
      */
-    public static final ConfigKey<List<String>> REDIS_ADDRESSES = notReloadable(stringListKey("redis.addresses", null));
+    @Deprecated
+    public static final ConfigKey<String> REDIS_ADDRESS = notReloadable(stringKey("redis.address", ""));
+
+    /**
+     * The addresses of the redis server
+     */
+    public static final ConfigKey<List<String>> REDIS_ADDRESSES = notReloadable(stringListKey("redis.addresses", new ArrayList<>()));
 
     /**
      * The username to connect with, or an empty string if it should use default

--- a/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
@@ -632,13 +632,13 @@ public final class ConfigKeys {
     /**
      * The address of the redis server
      *
-     * @deprecated use {@link #REDIS_ADDRESSES}
+     * @deprecated The Config Key is only available for backwards compatibility. Please use {@link #REDIS_ADDRESSES}
      */
     @Deprecated
     public static final ConfigKey<String> REDIS_ADDRESS = notReloadable(stringKey("redis.address", ""));
 
     /**
-     * The addresses of the redis server
+     * The addresses of the redis servers
      */
     public static final ConfigKey<List<String>> REDIS_ADDRESSES = notReloadable(stringListKey("redis.addresses", new ArrayList<>()));
 

--- a/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Maps;
 import me.lucko.luckperms.common.cacheddata.type.SimpleMetaValueSelector;
 import me.lucko.luckperms.common.config.generic.KeyedConfiguration;
 import me.lucko.luckperms.common.config.generic.key.ConfigKey;
+import static me.lucko.luckperms.common.config.generic.key.ConfigKeyFactory.*;
 import me.lucko.luckperms.common.config.generic.key.SimpleConfigKey;
 import me.lucko.luckperms.common.context.calculator.WorldNameRewriter;
 import me.lucko.luckperms.common.graph.TraversalAlgorithm;
@@ -66,13 +67,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-
-import static me.lucko.luckperms.common.config.generic.key.ConfigKeyFactory.booleanKey;
-import static me.lucko.luckperms.common.config.generic.key.ConfigKeyFactory.key;
-import static me.lucko.luckperms.common.config.generic.key.ConfigKeyFactory.lowercaseStringKey;
-import static me.lucko.luckperms.common.config.generic.key.ConfigKeyFactory.mapKey;
-import static me.lucko.luckperms.common.config.generic.key.ConfigKeyFactory.notReloadable;
-import static me.lucko.luckperms.common.config.generic.key.ConfigKeyFactory.stringKey;
 
 /**
  * All of the {@link ConfigKey}s used by LuckPerms.
@@ -637,7 +631,7 @@ public final class ConfigKeys {
     /**
      * The address of the redis server
      */
-    public static final ConfigKey<String> REDIS_ADDRESS = notReloadable(stringKey("redis.address", null));
+    public static final ConfigKey<List<String>> REDIS_ADDRESSES = notReloadable(stringListKey("redis.addresses", null));
 
     /**
      * The username to connect with, or an empty string if it should use default

--- a/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
@@ -67,7 +67,13 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import static me.lucko.luckperms.common.config.generic.key.ConfigKeyFactory.*;
+import static me.lucko.luckperms.common.config.generic.key.ConfigKeyFactory.booleanKey;
+import static me.lucko.luckperms.common.config.generic.key.ConfigKeyFactory.key;
+import static me.lucko.luckperms.common.config.generic.key.ConfigKeyFactory.lowercaseStringKey;
+import static me.lucko.luckperms.common.config.generic.key.ConfigKeyFactory.mapKey;
+import static me.lucko.luckperms.common.config.generic.key.ConfigKeyFactory.notReloadable;
+import static me.lucko.luckperms.common.config.generic.key.ConfigKeyFactory.stringKey;
+import static me.lucko.luckperms.common.config.generic.key.ConfigKeyFactory.stringListKey;
 
 /**
  * All of the {@link ConfigKey}s used by LuckPerms.
@@ -637,7 +643,7 @@ public final class ConfigKeys {
     /**
      * The addresses of the redis servers (only for redis clusters)
      */
-    public static final ConfigKey<List<String>> REDIS_ADDRESSES = notReloadable(stringListKey("redis.addresses", new ArrayList<>()));
+    public static final ConfigKey<List<String>> REDIS_ADDRESSES = notReloadable(stringListKey("redis.addresses", ImmutableList.of()));
 
     /**
      * The username to connect with, or an empty string if it should use default

--- a/common/src/main/java/me/lucko/luckperms/common/config/generic/key/ConfigKeyFactory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/generic/key/ConfigKeyFactory.java
@@ -26,9 +26,9 @@
 package me.lucko.luckperms.common.config.generic.key;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.List;
 import me.lucko.luckperms.common.config.generic.adapter.ConfigurationAdapter;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;

--- a/common/src/main/java/me/lucko/luckperms/common/config/generic/key/ConfigKeyFactory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/generic/key/ConfigKeyFactory.java
@@ -26,6 +26,7 @@
 package me.lucko.luckperms.common.config.generic.key;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
 import me.lucko.luckperms.common.config.generic.adapter.ConfigurationAdapter;
 
 import java.util.Locale;
@@ -36,6 +37,7 @@ public interface ConfigKeyFactory<T> {
 
     ConfigKeyFactory<Boolean> BOOLEAN = ConfigurationAdapter::getBoolean;
     ConfigKeyFactory<String> STRING = ConfigurationAdapter::getString;
+    ConfigKeyFactory<List<String>> STRING_LIST = ConfigurationAdapter::getStringList;
     ConfigKeyFactory<String> LOWERCASE_STRING = (adapter, path, def) -> adapter.getString(path, def).toLowerCase(Locale.ROOT);
     ConfigKeyFactory<Map<String, String>> STRING_MAP = (config, path, def) -> ImmutableMap.copyOf(config.getStringMap(path, ImmutableMap.of()));
 
@@ -54,6 +56,10 @@ public interface ConfigKeyFactory<T> {
 
     static SimpleConfigKey<String> stringKey(String path, String def) {
         return key(new Bound<>(STRING, path, def));
+    }
+
+    static SimpleConfigKey<List<String>> stringListKey(String path, List<String> def) {
+        return key(new Bound<>(STRING_LIST, path, def));
     }
 
     static SimpleConfigKey<String> lowercaseStringKey(String path, String def) {

--- a/common/src/main/java/me/lucko/luckperms/common/dependencies/Dependency.java
+++ b/common/src/main/java/me/lucko/luckperms/common/dependencies/Dependency.java
@@ -239,8 +239,8 @@ public enum Dependency {
     JEDIS(
             "redis.clients",
             "jedis",
-            "3.5.2",
-            "jX3340YaYjHFQN2sA+GCo33LB4FuIYKgQUPUv2MK/Xo=",
+            "4.4.2",
+            "BKld7E+Ldvre7C/7/rIrKPTz/za52dTGSijEpM57bjw=",
             Relocation.of("jedis", "redis{}clients{}jedis"),
             Relocation.of("commonspool2", "org{}apache{}commons{}pool2")
     ),

--- a/common/src/main/java/me/lucko/luckperms/common/dependencies/Dependency.java
+++ b/common/src/main/java/me/lucko/luckperms/common/dependencies/Dependency.java
@@ -239,8 +239,8 @@ public enum Dependency {
     JEDIS(
             "redis.clients",
             "jedis",
-            "4.4.2",
-            "BKld7E+Ldvre7C/7/rIrKPTz/za52dTGSijEpM57bjw=",
+            "4.4.3",
+            "wwwoCDPCywcfoNwpvwP95kXYusXSTtXhuVrB31sxE0k=",
             Relocation.of("jedis", "redis{}clients{}jedis"),
             Relocation.of("commonspool2", "org{}apache{}commons{}pool2")
     ),

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
@@ -25,9 +25,6 @@
 
 package me.lucko.luckperms.common.messaging;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 import me.lucko.luckperms.common.config.ConfigKeys;
 import me.lucko.luckperms.common.config.LuckPermsConfiguration;
 import me.lucko.luckperms.common.messaging.nats.NatsMessenger;
@@ -46,6 +43,9 @@ import net.luckperms.api.messenger.Messenger;
 import net.luckperms.api.messenger.MessengerProvider;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import java.util.Locale;
 
 public class MessagingFactory<P extends LuckPermsPlugin> {

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
@@ -25,6 +25,7 @@
 
 package me.lucko.luckperms.common.messaging;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import me.lucko.luckperms.common.config.ConfigKeys;
@@ -195,7 +196,7 @@ public class MessagingFactory<P extends LuckPermsPlugin> {
             RedisMessenger redis = new RedisMessenger(getPlugin(), incomingMessageConsumer);
 
             LuckPermsConfiguration config = getPlugin().getConfiguration();
-            List<String> addresses = config.get(ConfigKeys.REDIS_ADDRESSES);
+            List<String> addresses = new ArrayList<>(config.get(ConfigKeys.REDIS_ADDRESSES));
             String username = config.get(ConfigKeys.REDIS_USERNAME);
             String password = config.get(ConfigKeys.REDIS_PASSWORD);
             if (password.isEmpty()) {

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
@@ -25,6 +25,7 @@
 
 package me.lucko.luckperms.common.messaging;
 
+import java.util.List;
 import me.lucko.luckperms.common.config.ConfigKeys;
 import me.lucko.luckperms.common.config.LuckPermsConfiguration;
 import me.lucko.luckperms.common.messaging.nats.NatsMessenger;
@@ -193,7 +194,7 @@ public class MessagingFactory<P extends LuckPermsPlugin> {
             RedisMessenger redis = new RedisMessenger(getPlugin(), incomingMessageConsumer);
 
             LuckPermsConfiguration config = getPlugin().getConfiguration();
-            String address = config.get(ConfigKeys.REDIS_ADDRESS);
+            List<String> addresses = config.get(ConfigKeys.REDIS_ADDRESSES);
             String username = config.get(ConfigKeys.REDIS_USERNAME);
             String password = config.get(ConfigKeys.REDIS_PASSWORD);
             if (password.isEmpty()) {
@@ -204,7 +205,7 @@ public class MessagingFactory<P extends LuckPermsPlugin> {
             }
             boolean ssl = config.get(ConfigKeys.REDIS_SSL);
 
-            redis.init(address, username, password, ssl);
+            redis.init(addresses, username, password, ssl);
             return redis;
         }
     }

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
@@ -26,6 +26,7 @@
 package me.lucko.luckperms.common.messaging;
 
 import java.util.List;
+import java.util.Optional;
 import me.lucko.luckperms.common.config.ConfigKeys;
 import me.lucko.luckperms.common.config.LuckPermsConfiguration;
 import me.lucko.luckperms.common.messaging.nats.NatsMessenger;
@@ -204,6 +205,8 @@ public class MessagingFactory<P extends LuckPermsPlugin> {
                 username = null;
             }
             boolean ssl = config.get(ConfigKeys.REDIS_SSL);
+
+            Optional.ofNullable(config.get(ConfigKeys.REDIS_ADDRESS)).ifPresent(addresses::add);
 
             redis.init(addresses, username, password, ssl);
             return redis;

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/redis/RedisMessenger.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/redis/RedisMessenger.java
@@ -25,6 +25,7 @@
 
 package me.lucko.luckperms.common.messaging.redis;
 
+import java.util.List;
 import me.lucko.luckperms.common.plugin.LuckPermsPlugin;
 import net.luckperms.api.messenger.IncomingMessageConsumer;
 import net.luckperms.api.messenger.Messenger;
@@ -54,8 +55,8 @@ public class RedisMessenger implements Messenger {
         this.consumer = consumer;
     }
 
-    public void init(String address, String username, String password, boolean ssl) {
-        String[] addressSplit = address.split(":");
+    public void init(List<String> addresses, String username, String password, boolean ssl) {
+        String[] addressSplit = addresses.get(0).split(":"); // TODO: Only for config testing
         String host = addressSplit[0];
         int port = addressSplit.length > 1 ? Integer.parseInt(addressSplit[1]) : Protocol.DEFAULT_PORT;
 

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/redis/RedisMessenger.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/redis/RedisMessenger.java
@@ -25,10 +25,6 @@
 
 package me.lucko.luckperms.common.messaging.redis;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 import me.lucko.luckperms.common.plugin.LuckPermsPlugin;
 import net.luckperms.api.messenger.IncomingMessageConsumer;
 import net.luckperms.api.messenger.Messenger;
@@ -43,6 +39,11 @@ import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPubSub;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.exceptions.JedisClusterOperationException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * An implementation of {@link Messenger} using Redis.

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/redis/RedisMessenger.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/redis/RedisMessenger.java
@@ -110,7 +110,7 @@ public class RedisMessenger implements Messenger {
     @Override
     public void close() {
         this.closing = true;
-        this.sub.unsubscribe();
+        if (this.sub != null) this.sub.unsubscribe();
         if (this.jedisCluster != null) this.jedisCluster.close();
         if (this.jedisPool != null) this.jedisPool.destroy();
     }

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/redis/RedisMessenger.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/redis/RedisMessenger.java
@@ -80,9 +80,14 @@ public class RedisMessenger implements Messenger {
         JedisClientConfig config = jedisClientConfig.build();
         try {
             this.jedisCluster = new JedisCluster(hosts, config);
-            this.plugin.getLogger().info("Redis Cluster supported was detected!");
+            this.plugin.getLogger().info("Redis Cluster support was detected!");
         } catch (JedisClusterOperationException e) {
             // The Redis cluster could not be initialized. Therefore, we do not use the cluster support.
+
+            if (addresses.size() > 1) {
+                this.plugin.getLogger().warn("The Redis cluster support seems to be disabled, and the connection to Redis is now only being attempted with a single node.");
+            }
+
             Optional<HostAndPort> hostAndPort = hosts.stream().findAny();
             if (hostAndPort.isPresent()) {
                 this.jedisPool = new JedisPool(hostAndPort.get(), config);

--- a/fabric/src/main/resources/luckperms.conf
+++ b/fabric/src/main/resources/luckperms.conf
@@ -267,7 +267,9 @@ broadcast-received-log-entries = true
 # Port 6379 is used by default; set address to "host:port" if differs
 redis {
   enabled = false
-  address = "localhost"
+  addresses = [
+    "localhost"
+  ]
   username = ""
   password = ""
 }

--- a/fabric/src/main/resources/luckperms.conf
+++ b/fabric/src/main/resources/luckperms.conf
@@ -264,7 +264,7 @@ push-log-entries = true
 broadcast-received-log-entries = true
 
 # Settings for Redis.
-# Port 6379 is used by default; set address to "host:port" if differs
+# Port 6379 is used by default; paste the addresses of your nodes in the format "host:port" under addresses.
 redis {
   enabled = false
   addresses = [

--- a/fabric/src/main/resources/luckperms.conf
+++ b/fabric/src/main/resources/luckperms.conf
@@ -264,12 +264,11 @@ push-log-entries = true
 broadcast-received-log-entries = true
 
 # Settings for Redis.
-# Port 6379 is used by default; paste the addresses of your nodes in the format "host:port" under addresses.
+# Port 6379 is used by default; set address to "host:port" if differs
+# Multiple Redis nodes can be specified in the same format as a string list under the name "addresses".
 redis {
   enabled = false
-  addresses = [
-    "localhost"
-  ]
+  address = "localhost"
   username = ""
   password = ""
 }

--- a/forge/src/main/resources/luckperms.conf
+++ b/forge/src/main/resources/luckperms.conf
@@ -262,7 +262,7 @@ push-log-entries = true
 broadcast-received-log-entries = true
 
 # Settings for Redis.
-# Port 6379 is used by default; set address to "host:port" if differs
+# Port 6379 is used by default; paste the addresses of your nodes in the format "host:port" under addresses.
 redis {
   enabled = false
   addresses = [

--- a/forge/src/main/resources/luckperms.conf
+++ b/forge/src/main/resources/luckperms.conf
@@ -265,7 +265,9 @@ broadcast-received-log-entries = true
 # Port 6379 is used by default; set address to "host:port" if differs
 redis {
   enabled = false
-  address = "localhost"
+  addresses = [
+    "localhost"
+  ]
   username = ""
   password = ""
 }

--- a/forge/src/main/resources/luckperms.conf
+++ b/forge/src/main/resources/luckperms.conf
@@ -262,12 +262,11 @@ push-log-entries = true
 broadcast-received-log-entries = true
 
 # Settings for Redis.
-# Port 6379 is used by default; paste the addresses of your nodes in the format "host:port" under addresses.
+# Port 6379 is used by default; set address to "host:port" if differs
+# Multiple Redis nodes can be specified in the same format as a string list under the name "addresses".
 redis {
   enabled = false
-  addresses = [
-    "localhost"
-  ]
+  address = "localhost"
   username = ""
   password = ""
 }

--- a/nukkit/src/main/resources/config.yml
+++ b/nukkit/src/main/resources/config.yml
@@ -256,11 +256,11 @@ push-log-entries: true
 broadcast-received-log-entries: true
 
 # Settings for Redis.
-# Port 6379 is used by default; paste the addresses of your nodes in the format "host:port" under addresses.
+# Port 6379 is used by default; set address to "host:port" if differs
+# Multiple Redis nodes can be specified in the same format as a string list under the name "addresses".
 redis:
   enabled: false
-  addresses:
-    - localhost
+  address: localhost
   username: ''
   password: ''
 

--- a/nukkit/src/main/resources/config.yml
+++ b/nukkit/src/main/resources/config.yml
@@ -259,7 +259,8 @@ broadcast-received-log-entries: true
 # Port 6379 is used by default; set address to "host:port" if differs
 redis:
   enabled: false
-  address: localhost
+  addresses:
+    - localhost
   username: ''
   password: ''
 

--- a/nukkit/src/main/resources/config.yml
+++ b/nukkit/src/main/resources/config.yml
@@ -256,7 +256,7 @@ push-log-entries: true
 broadcast-received-log-entries: true
 
 # Settings for Redis.
-# Port 6379 is used by default; set address to "host:port" if differs
+# Port 6379 is used by default; paste the addresses of your nodes in the format "host:port" under addresses.
 redis:
   enabled: false
   addresses:

--- a/sponge/src/main/resources/luckperms.conf
+++ b/sponge/src/main/resources/luckperms.conf
@@ -264,7 +264,7 @@ push-log-entries = true
 broadcast-received-log-entries = true
 
 # Settings for Redis.
-# Port 6379 is used by default; set address to "host:port" if differs
+# Port 6379 is used by default; paste the addresses of your nodes in the format "host:port" under addresses.
 redis {
   enabled = false
   address = [

--- a/sponge/src/main/resources/luckperms.conf
+++ b/sponge/src/main/resources/luckperms.conf
@@ -267,7 +267,9 @@ broadcast-received-log-entries = true
 # Port 6379 is used by default; set address to "host:port" if differs
 redis {
   enabled = false
-  address = "localhost"
+  address = [
+    "localhost"
+  ]
   username = ""
   password = ""
 }

--- a/sponge/src/main/resources/luckperms.conf
+++ b/sponge/src/main/resources/luckperms.conf
@@ -264,12 +264,11 @@ push-log-entries = true
 broadcast-received-log-entries = true
 
 # Settings for Redis.
-# Port 6379 is used by default; paste the addresses of your nodes in the format "host:port" under addresses.
+# Port 6379 is used by default; set address to "host:port" if differs
+# Multiple Redis nodes can be specified in the same format as a string list under the name "addresses".
 redis {
   enabled = false
-  address = [
-    "localhost"
-  ]
+  address = "localhost"
   username = ""
   password = ""
 }

--- a/standalone/build.gradle
+++ b/standalone/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     testImplementation 'org.awaitility:awaitility:4.2.0'
 
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:3.5.2'
+    testImplementation 'redis.clients:jedis:4.4.2'
     testImplementation 'io.nats:jnats:2.16.4'
     testImplementation 'com.rabbitmq:amqp-client:5.12.0'
     testImplementation 'org.postgresql:postgresql:42.6.0'

--- a/standalone/build.gradle
+++ b/standalone/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     testImplementation 'org.awaitility:awaitility:4.2.0'
 
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:4.4.2'
+    testImplementation 'redis.clients:jedis:4.4.3'
     testImplementation 'io.nats:jnats:2.16.4'
     testImplementation 'com.rabbitmq:amqp-client:5.12.0'
     testImplementation 'org.postgresql:postgresql:42.6.0'

--- a/standalone/src/main/resources/config.yml
+++ b/standalone/src/main/resources/config.yml
@@ -246,11 +246,11 @@ push-log-entries: true
 broadcast-received-log-entries: true
 
 # Settings for Redis.
-# Port 6379 is used by default; paste the addresses of your nodes in the format "host:port" under addresses.
+# Port 6379 is used by default; set address to "host:port" if differs
+# Multiple Redis nodes can be specified in the same format as a string list under the name "addresses".
 redis:
   enabled: false
-  addresses:
-    - localhost
+  address: localhost
   username: ''
   password: ''
 

--- a/standalone/src/main/resources/config.yml
+++ b/standalone/src/main/resources/config.yml
@@ -246,7 +246,7 @@ push-log-entries: true
 broadcast-received-log-entries: true
 
 # Settings for Redis.
-# Port 6379 is used by default; set address to "host:port" if differs
+# Port 6379 is used by default; paste the addresses of your nodes in the format "host:port" under addresses.
 redis:
   enabled: false
   addresses:

--- a/standalone/src/main/resources/config.yml
+++ b/standalone/src/main/resources/config.yml
@@ -249,7 +249,8 @@ broadcast-received-log-entries: true
 # Port 6379 is used by default; set address to "host:port" if differs
 redis:
   enabled: false
-  address: localhost
+  addresses:
+    - localhost
   username: ''
   password: ''
 

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -250,7 +250,7 @@ push-log-entries: true
 broadcast-received-log-entries: false
 
 # Settings for Redis.
-# Port 6379 is used by default; set address to "host:port" if differs
+# Port 6379 is used by default; paste the addresses of your nodes in the format "host:port" under addresses.
 redis:
   enabled: false
   addresses:

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -250,11 +250,11 @@ push-log-entries: true
 broadcast-received-log-entries: false
 
 # Settings for Redis.
-# Port 6379 is used by default; paste the addresses of your nodes in the format "host:port" under addresses.
+# Port 6379 is used by default; set address to "host:port" if differs
+# Multiple Redis nodes can be specified in the same format as a string list under the name "addresses".
 redis:
   enabled: false
-  addresses:
-    - localhost
+  address: localhost
   username: ''
   password: ''
 

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -253,7 +253,8 @@ broadcast-received-log-entries: false
 # Port 6379 is used by default; set address to "host:port" if differs
 redis:
   enabled: false
-  address: localhost
+  addresses:
+    - localhost
   username: ''
   password: ''
 


### PR DESCRIPTION
I once expanded the Redis support so that you can also use messaging with a Redis cluster.

I only made `addresses` from the `adress` in the config and a string list where you can specify the IP addresses and ports of your Redis nodes.