### PR TITLE
Improve "console" detection on fabric

### DIFF
--- a/fabric/src/main/java/me/lucko/luckperms/fabric/FabricSenderFactory.java
+++ b/fabric/src/main/java/me/lucko/luckperms/fabric/FabricSenderFactory.java
@@ -29,12 +29,15 @@ import me.lucko.fabric.api.permissions.v0.Permissions;
 import me.lucko.luckperms.common.locale.TranslationManager;
 import me.lucko.luckperms.common.sender.Sender;
 import me.lucko.luckperms.common.sender.SenderFactory;
+import me.lucko.luckperms.fabric.mixin.ServerCommandSourceAccessor;
 import me.lucko.luckperms.fabric.model.MixinUser;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.luckperms.api.util.Tristate;
+import net.minecraft.server.command.CommandOutput;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.rcon.RconCommandOutput;
 import net.minecraft.text.Text;
 
 import java.util.Locale;
@@ -107,7 +110,10 @@ public class FabricSenderFactory extends SenderFactory<LPFabricPlugin, ServerCom
 
     @Override
     protected boolean isConsole(ServerCommandSource sender) {
-        return sender.getEntity() == null;
+        CommandOutput output = ((ServerCommandSourceAccessor) sender).getOutput();
+        return output == sender.getServer() || // Console
+            output.getClass() == RconCommandOutput.class || // Rcon
+            (output == CommandOutput.DUMMY && sender.getName().equals("")); // Functions
     }
 
     public static Text toNativeText(Component component) {

--- a/fabric/src/main/java/me/lucko/luckperms/fabric/mixin/ServerCommandSourceAccessor.java
+++ b/fabric/src/main/java/me/lucko/luckperms/fabric/mixin/ServerCommandSourceAccessor.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of LuckPerms, licensed under the MIT License.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+package me.lucko.luckperms.fabric.mixin;
+
+import net.minecraft.server.command.CommandOutput;
+import net.minecraft.server.command.ServerCommandSource;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+/**
+ * Accessor mixin to provide access to the underlying {@link CommandOutput}
+ */
+@Mixin(ServerCommandSource.class)
+public interface ServerCommandSourceAccessor {
+
+    @Accessor("output")
+    CommandOutput getOutput();
+
+}

--- a/fabric/src/main/resources/luckperms.mixins.json
+++ b/fabric/src/main/resources/luckperms.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "CommandManagerMixin",
+    "ServerCommandSourceAccessor",
     "ServerLoginNetworkHandlerAccessor",
     "ServerPlayerEntityMixin"
   ],

--- a/forge/src/main/java/me/lucko/luckperms/forge/ForgeSenderFactory.java
+++ b/forge/src/main/java/me/lucko/luckperms/forge/ForgeSenderFactory.java
@@ -38,8 +38,10 @@ import me.lucko.luckperms.forge.capabilities.UserCapabilityImpl;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.luckperms.api.util.Tristate;
+import net.minecraft.commands.CommandSource;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.rcon.RconConsoleSource;
 import net.minecraft.world.entity.player.Player;
 
 import java.util.Locale;
@@ -107,7 +109,10 @@ public class ForgeSenderFactory extends SenderFactory<LPForgePlugin, CommandSour
 
     @Override
     protected boolean isConsole(CommandSourceStack sender) {
-        return !(sender.getEntity() instanceof Player);
+        CommandSource output = sender.source;
+        return output == sender.getServer() || // Console
+                output.getClass() == RconConsoleSource.class || // Rcon
+                (output == CommandSource.NULL && sender.getTextName().equals("")); // Functions
     }
 
     public static net.minecraft.network.chat.Component toNativeText(Component component) {


### PR DESCRIPTION
The fabric console detection currently simply checks if the `ServerCommandSource` has an entity "attached".
However, this causes two problems:

1. The execute command can attach entities to the command source, eg: `/execute as @a run lp user @s parent add player`. When this command is executed from the console, only players with permission to run `lp user @s parent add player` will receive the group. The version info message is printed into the console for any other player. Allowing modifiers like this allows for better datapack integration with luckperms commands. 
2. There is currently a small security issue. It is currently possible to run any luckperms commands as an OP player, by using a command block to execute them (because that doesn't have an entity attached), even though OP players can't execute luckperms commands by default.

This PR rewrites the fabric `isConsole()` check to use the `CommandOutput` instead. To explicitly check the command source against console, functions and rcon.