### PR TITLE
Update Github links to LuckPerms/LuckPerms

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Before reporting a bug or issue, please make sure that the issue is actually bei
 
 If you're unsure, feel free to ask using the above resources BEFORE making a report.
 
-Bugs or issues should be reported using the [GitHub Issues tab](https://github.com/lucko/LuckPerms/issues).
+Bugs or issues should be reported using the [GitHub Issues tab](https://github.com/LuckPerms/LuckPerms/issues).
 
 ### :pencil: Want to contribute code?
 #### Pull Requests

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ LuckPerms uses Gradle to handle dependencies & building.
 
 #### Compiling from source
 ```sh
-git clone https://github.com/lucko/LuckPerms.git
+git clone https://github.com/LuckPerms/LuckPerms.git
 cd LuckPerms/
 ./gradlew build
 ```
@@ -56,4 +56,4 @@ The project is split up into a few separate modules.
 * **Bukkit, BungeeCord, Fabric, Forge, Nukkit, Sponge & Velocity** - Each use the common module to implement plugins on the respective server platforms.
 
 ## License
-LuckPerms is licensed under the permissive MIT license. Please see [`LICENSE.txt`](https://github.com/lucko/LuckPerms/blob/master/LICENSE.txt) for more info.
+LuckPerms is licensed under the permissive MIT license. Please see [`LICENSE.txt`](https://github.com/LuckPerms/LuckPerms/blob/master/LICENSE.txt) for more info.

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/LPBukkitPlugin.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/LPBukkitPlugin.java
@@ -217,7 +217,7 @@ public class LPBukkitPlugin extends AbstractLuckPermsPlugin {
          * Vault in their onEnable without depending on us.
          *
          * Noteworthy discussion here:
-         * - https://github.com/lucko/LuckPerms/issues/1959
+         * - https://github.com/LuckPerms/LuckPerms/issues/1959
          * - https://hub.spigotmc.org/jira/browse/SPIGOT-5546
          * - https://github.com/PaperMC/Paper/pull/3509
          */

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -8,7 +8,7 @@
 # |                                                                                              | #
 # |  WIKI:        https://luckperms.net/wiki                                                     | #
 # |  DISCORD:     https://discord.gg/luckperms                                                   | #
-# |  BUG REPORTS: https://github.com/lucko/LuckPerms/issues                                      | #
+# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                      | #
 # |                                                                                              | #
 # |  Each option in this file is documented and explained here:                                  | #
 # |   ==>  https://luckperms.net/wiki/Configuration                                              | #

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -8,7 +8,7 @@
 # |                                                                                              | #
 # |  WIKI:        https://luckperms.net/wiki                                                     | #
 # |  DISCORD:     https://discord.gg/luckperms                                                   | #
-# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                      | #
+# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                  | #
 # |                                                                                              | #
 # |  Each option in this file is documented and explained here:                                  | #
 # |   ==>  https://luckperms.net/wiki/Configuration                                              | #

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -8,7 +8,7 @@
 # |                                                                                              | #
 # |  WIKI:        https://luckperms.net/wiki                                                     | #
 # |  DISCORD:     https://discord.gg/luckperms                                                   | #
-# |  BUG REPORTS: https://github.com/lucko/LuckPerms/issues                                      | #
+# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                      | #
 # |                                                                                              | #
 # |  Each option in this file is documented and explained here:                                  | #
 # |   ==>  https://luckperms.net/wiki/Configuration                                              | #

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -8,7 +8,7 @@
 # |                                                                                              | #
 # |  WIKI:        https://luckperms.net/wiki                                                     | #
 # |  DISCORD:     https://discord.gg/luckperms                                                   | #
-# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                      | #
+# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                  | #
 # |                                                                                              | #
 # |  Each option in this file is documented and explained here:                                  | #
 # |   ==>  https://luckperms.net/wiki/Configuration                                              | #

--- a/common/src/main/java/me/lucko/luckperms/common/plugin/AbstractLuckPermsPlugin.java
+++ b/common/src/main/java/me/lucko/luckperms/common/plugin/AbstractLuckPermsPlugin.java
@@ -175,7 +175,7 @@ public abstract class AbstractLuckPermsPlugin implements LuckPermsPlugin {
                 this.fileWatcher = new FileWatcher(this, getBootstrap().getDataDirectory());
             } catch (Throwable e) {
                 // catch throwable here, seems some JVMs throw UnsatisfiedLinkError when trying
-                // to create a watch service. see: https://github.com/lucko/LuckPerms/issues/2066
+                // to create a watch service. see: https://github.com/LuckPerms/LuckPerms/issues/2066
                 getLogger().warn("Error occurred whilst trying to create a file watcher:", e);
             }
         }

--- a/common/src/main/java/me/lucko/luckperms/common/util/UniqueIdType.java
+++ b/common/src/main/java/me/lucko/luckperms/common/util/UniqueIdType.java
@@ -79,8 +79,8 @@ public final class UniqueIdType {
                 break;
             case 2:
                 // if the uuid is version 2, assume it is an NPC
-                // see: https://github.com/lucko/LuckPerms/issues/1470
-                // and https://github.com/lucko/LuckPerms/issues/1470#issuecomment-475403162
+                // see: https://github.com/LuckPerms/LuckPerms/issues/1470
+                // and https://github.com/LuckPerms/LuckPerms/issues/1470#issuecomment-475403162
                 type = UniqueIdDetermineTypeEvent.TYPE_NPC;
                 break;
             default:

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -17,8 +17,8 @@
   "license": "MIT",
   "contact": {
     "homepage": "https://luckperms.net",
-    "source": "https://github.com/lucko/LuckPerms",
-    "issues": "https://github.com/lucko/LuckPerms/issues"
+    "source": "https://github.com/LuckPerms/LuckPerms",
+    "issues": "https://github.com/LuckPerms/LuckPerms/issues"
   },
   "environment": "server",
   "entrypoints": {

--- a/fabric/src/main/resources/luckperms.conf
+++ b/fabric/src/main/resources/luckperms.conf
@@ -8,7 +8,7 @@
 # |                                                                                              | #
 # |  WIKI:        https://luckperms.net/wiki                                                     | #
 # |  DISCORD:     https://discord.gg/luckperms                                                   | #
-# |  BUG REPORTS: https://github.com/lucko/LuckPerms/issues                                      | #
+# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                      | #
 # |                                                                                              | #
 # |  Each option in this file is documented and explained here:                                  | #
 # |   ==>  https://luckperms.net/wiki/Configuration                                              | #

--- a/fabric/src/main/resources/luckperms.conf
+++ b/fabric/src/main/resources/luckperms.conf
@@ -8,7 +8,7 @@
 # |                                                                                              | #
 # |  WIKI:        https://luckperms.net/wiki                                                     | #
 # |  DISCORD:     https://discord.gg/luckperms                                                   | #
-# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                      | #
+# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                  | #
 # |                                                                                              | #
 # |  Each option in this file is documented and explained here:                                  | #
 # |   ==>  https://luckperms.net/wiki/Configuration                                              | #

--- a/forge/src/main/resources/luckperms.conf
+++ b/forge/src/main/resources/luckperms.conf
@@ -8,7 +8,7 @@
 # |                                                                                              | #
 # |  WIKI:        https://luckperms.net/wiki                                                     | #
 # |  DISCORD:     https://discord.gg/luckperms                                                   | #
-# |  BUG REPORTS: https://github.com/lucko/LuckPerms/issues                                      | #
+# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                      | #
 # |                                                                                              | #
 # |  Each option in this file is documented and explained here:                                  | #
 # |   ==>  https://luckperms.net/wiki/Configuration                                              | #

--- a/forge/src/main/resources/luckperms.conf
+++ b/forge/src/main/resources/luckperms.conf
@@ -8,7 +8,7 @@
 # |                                                                                              | #
 # |  WIKI:        https://luckperms.net/wiki                                                     | #
 # |  DISCORD:     https://discord.gg/luckperms                                                   | #
-# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                      | #
+# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                  | #
 # |                                                                                              | #
 # |  Each option in this file is documented and explained here:                                  | #
 # |   ==>  https://luckperms.net/wiki/Configuration                                              | #

--- a/nukkit/src/main/java/me/lucko/luckperms/nukkit/inject/permissible/PermissibleInjector.java
+++ b/nukkit/src/main/java/me/lucko/luckperms/nukkit/inject/permissible/PermissibleInjector.java
@@ -82,7 +82,7 @@ public final class PermissibleInjector {
         if (oldPermissible instanceof LuckPermsPermissible) {
             // Nukkit seems to re-use player instances (or perhaps calls the login event twice?)
             // so, just uninject here instead of throwing an exception like we do on Bukkit
-            // See: https://github.com/lucko/LuckPerms/issues/2791
+            // See: https://github.com/LuckPerms/LuckPerms/issues/2791
             uninject(player, false);
         }
 

--- a/nukkit/src/main/java/me/lucko/luckperms/nukkit/listeners/NukkitConnectionListener.java
+++ b/nukkit/src/main/java/me/lucko/luckperms/nukkit/listeners/NukkitConnectionListener.java
@@ -193,7 +193,7 @@ public class NukkitConnectionListener extends AbstractConnectionListener impleme
     public void onPlayerQuit(PlayerQuitEvent e) {
         final Player player = e.getPlayer();
 
-        // https://github.com/lucko/LuckPerms/issues/2269
+        // https://github.com/LuckPerms/LuckPerms/issues/2269
         if (player.getUniqueId() == null) {
             return;
         }

--- a/nukkit/src/main/resources/config.yml
+++ b/nukkit/src/main/resources/config.yml
@@ -8,7 +8,7 @@
 # |                                                                                              | #
 # |  WIKI:        https://luckperms.net/wiki                                                     | #
 # |  DISCORD:     https://discord.gg/luckperms                                                   | #
-# |  BUG REPORTS: https://github.com/lucko/LuckPerms/issues                                      | #
+# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                      | #
 # |                                                                                              | #
 # |  Each option in this file is documented and explained here:                                  | #
 # |   ==>  https://luckperms.net/wiki/Configuration                                              | #

--- a/nukkit/src/main/resources/config.yml
+++ b/nukkit/src/main/resources/config.yml
@@ -8,7 +8,7 @@
 # |                                                                                              | #
 # |  WIKI:        https://luckperms.net/wiki                                                     | #
 # |  DISCORD:     https://discord.gg/luckperms                                                   | #
-# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                      | #
+# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                  | #
 # |                                                                                              | #
 # |  Each option in this file is documented and explained here:                                  | #
 # |   ==>  https://luckperms.net/wiki/Configuration                                              | #

--- a/sponge/src/main/resources/luckperms.conf
+++ b/sponge/src/main/resources/luckperms.conf
@@ -8,7 +8,7 @@
 # |                                                                                              | #
 # |  WIKI:        https://luckperms.net/wiki                                                     | #
 # |  DISCORD:     https://discord.gg/luckperms                                                   | #
-# |  BUG REPORTS: https://github.com/lucko/LuckPerms/issues                                      | #
+# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                      | #
 # |                                                                                              | #
 # |  Each option in this file is documented and explained here:                                  | #
 # |   ==>  https://luckperms.net/wiki/Configuration                                              | #

--- a/sponge/src/main/resources/luckperms.conf
+++ b/sponge/src/main/resources/luckperms.conf
@@ -8,7 +8,7 @@
 # |                                                                                              | #
 # |  WIKI:        https://luckperms.net/wiki                                                     | #
 # |  DISCORD:     https://discord.gg/luckperms                                                   | #
-# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                      | #
+# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                  | #
 # |                                                                                              | #
 # |  Each option in this file is documented and explained here:                                  | #
 # |   ==>  https://luckperms.net/wiki/Configuration                                              | #

--- a/standalone/src/main/resources/config.yml
+++ b/standalone/src/main/resources/config.yml
@@ -8,7 +8,7 @@
 # |                                                                                              | #
 # |  WIKI:        https://luckperms.net/wiki                                                     | #
 # |  DISCORD:     https://discord.gg/luckperms                                                   | #
-# |  BUG REPORTS: https://github.com/lucko/LuckPerms/issues                                      | #
+# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                      | #
 # |                                                                                              | #
 # |  Each option in this file is documented and explained here:                                  | #
 # |   ==>  https://luckperms.net/wiki/Configuration                                              | #

--- a/standalone/src/main/resources/config.yml
+++ b/standalone/src/main/resources/config.yml
@@ -8,7 +8,7 @@
 # |                                                                                              | #
 # |  WIKI:        https://luckperms.net/wiki                                                     | #
 # |  DISCORD:     https://discord.gg/luckperms                                                   | #
-# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                      | #
+# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                  | #
 # |                                                                                              | #
 # |  Each option in this file is documented and explained here:                                  | #
 # |   ==>  https://luckperms.net/wiki/Configuration                                              | #

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -8,7 +8,7 @@
 # |                                                                                              | #
 # |  WIKI:        https://luckperms.net/wiki                                                     | #
 # |  DISCORD:     https://discord.gg/luckperms                                                   | #
-# |  BUG REPORTS: https://github.com/lucko/LuckPerms/issues                                      | #
+# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                      | #
 # |                                                                                              | #
 # |  Each option in this file is documented and explained here:                                  | #
 # |   ==>  https://luckperms.net/wiki/Configuration                                              | #

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -8,7 +8,7 @@
 # |                                                                                              | #
 # |  WIKI:        https://luckperms.net/wiki                                                     | #
 # |  DISCORD:     https://discord.gg/luckperms                                                   | #
-# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                      | #
+# |  BUG REPORTS: https://github.com/LuckPerms/LuckPerms/issues                                  | #
 # |                                                                                              | #
 # |  Each option in this file is documented and explained here:                                  | #
 # |   ==>  https://luckperms.net/wiki/Configuration                                              | #


### PR DESCRIPTION
Just a simple find and replace for `https://github.com/lucko/LuckPerms` to `https://github.com/LuckPerms/LuckPerms`. :)