### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -717,5 +717,5 @@ update-client-command-list: true
 register-command-list-data: true
 
 # If LuckPerms should attempt to resolve Vanilla command target selectors for LP commands.
-# See here for more info: https://minecraft.gamepedia.com/Commands#Target_selectors
+# See here for more info: https://minecraft.wiki/w/Target_selectors
 resolve-command-selectors: false

--- a/fabric/src/main/resources/luckperms.conf
+++ b/fabric/src/main/resources/luckperms.conf
@@ -648,5 +648,5 @@ prevent-primary-group-removal = false
 update-client-command-list = true
 
 # If LuckPerms should attempt to resolve Vanilla command target selectors for LP commands.
-# See here for more info: https://minecraft.gamepedia.com/Commands#Target_selectors
+# See here for more info: https://minecraft.wiki/w/Target_selectors
 resolve-command-selectors = false

--- a/forge/src/main/resources/luckperms.conf
+++ b/forge/src/main/resources/luckperms.conf
@@ -637,5 +637,5 @@ prevent-primary-group-removal = false
 update-client-command-list = true
 
 # If LuckPerms should attempt to resolve Vanilla command target selectors for LP commands.
-# See here for more info: https://minecraft.gamepedia.com/Commands#Target_selectors
+# See here for more info: https://minecraft.wiki/w/Target_selectors
 resolve-command-selectors = false

--- a/sponge/src/main/resources/luckperms.conf
+++ b/sponge/src/main/resources/luckperms.conf
@@ -635,5 +635,5 @@ prevent-primary-group-removal = false
 update-client-command-list = true
 
 # If LuckPerms should attempt to resolve Vanilla command target selectors for LP commands.
-# See here for more info: https://minecraft.gamepedia.com/Commands#Target_selectors
+# See here for more info: https://minecraft.wiki/w/Target_selectors
 resolve-command-selectors = false


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki

Also updates the URL since the resource was moved on the Minecraft Wiki