### PR TITLE
tiny performance tweak

### DIFF
--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/listeners/BukkitPlatformListener.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/listeners/BukkitPlatformListener.java
@@ -41,7 +41,7 @@ import java.util.Locale;
 import java.util.regex.Pattern;
 
 public class BukkitPlatformListener implements Listener {
-    private static final Pattern OP_COMMAND_PATTERN = Pattern.compile("^/?(\\w+:)?(deop|op)( .*)?$");
+    private static final Pattern OP_COMMAND_PATTERN = Pattern.compile("^/?(\\w+:)?(deop|op)( .*)?$", Pattern.CASE_INSENSITIVE);
 
     private final LPBukkitPlugin plugin;
 
@@ -51,17 +51,17 @@ public class BukkitPlatformListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onPlayerCommand(PlayerCommandPreprocessEvent e) {
-        handleCommand(e.getPlayer(), e.getMessage().toLowerCase(Locale.ROOT), e);
+        handleCommand(e.getPlayer(), e.getMessage(), e);
     }
 
     @EventHandler(ignoreCancelled = true)
     public void onServerCommand(ServerCommandEvent e) {
-        handleCommand(e.getSender(), e.getCommand().toLowerCase(Locale.ROOT), e);
+        handleCommand(e.getSender(), e.getCommand(), e);
     }
 
     @EventHandler(ignoreCancelled = true)
     public void onRemoteServerCommand(RemoteServerCommandEvent e) {
-        handleCommand(e.getSender(), e.getCommand().toLowerCase(Locale.ROOT), e);
+        handleCommand(e.getSender(), e.getCommand(), e);
     }
 
     private void handleCommand(CommandSender sender, String cmdLine, Cancellable event) {


### PR DESCRIPTION
Ran a spark profile the other day and noticed luckperms was the highest tick consuming plugin (still very minimal) but this change should help with that. https://imgur.com/LxnTEAJ