### PR TITLE
Fix environmental/property credentials leaking

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
@@ -755,4 +755,14 @@ public final class ConfigKeys {
         return KEYS;
     }
 
+    /**
+     * Check if the value at the given path should be censored in console/log output
+     *
+     * @param path the path
+     * @return true if the value should be censored
+     */
+    public static boolean shouldCensorValue(final String path) {
+        return path.contains("password") || path.contains("uri");
+    }
+
 }

--- a/common/src/main/java/me/lucko/luckperms/common/config/generic/adapter/EnvironmentVariableConfigAdapter.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/generic/adapter/EnvironmentVariableConfigAdapter.java
@@ -25,6 +25,7 @@
 
 package me.lucko.luckperms.common.config.generic.adapter;
 
+import me.lucko.luckperms.common.config.ConfigKeys;
 import me.lucko.luckperms.common.plugin.LuckPermsPlugin;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -50,7 +51,8 @@ public class EnvironmentVariableConfigAdapter extends StringBasedConfigurationAd
 
         String value = System.getenv(key);
         if (value != null) {
-            this.plugin.getLogger().info("Resolved configuration value from environment variable: " + key + " = " + (path.contains("password") ? "*****" : value));
+            String printableValue = ConfigKeys.shouldCensorValue(path) ? "*****" : value;
+            this.plugin.getLogger().info(String.format("Resolved configuration value from environment variable: %s = %s", key, printableValue));
         }
         return value;
     }

--- a/common/src/main/java/me/lucko/luckperms/common/config/generic/adapter/SystemPropertyConfigAdapter.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/generic/adapter/SystemPropertyConfigAdapter.java
@@ -25,6 +25,7 @@
 
 package me.lucko.luckperms.common.config.generic.adapter;
 
+import me.lucko.luckperms.common.config.ConfigKeys;
 import me.lucko.luckperms.common.plugin.LuckPermsPlugin;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -46,7 +47,8 @@ public class SystemPropertyConfigAdapter extends StringBasedConfigurationAdapter
 
         String value = System.getProperty(key);
         if (value != null) {
-            this.plugin.getLogger().info("Resolved configuration value from system property: " + key + " = " + (path.contains("password") ? "*****" : value));
+            String printableValue = ConfigKeys.shouldCensorValue(path) ? "*****" : value;
+            this.plugin.getLogger().info(String.format("Resolved configuration value from system property: %s = %s", key, printableValue));
         }
         return value;
     }


### PR DESCRIPTION
Tested with system properties, I assume it'll also work for environmental variables

![firefox_97KvFogAiw](https://github.com/LuckPerms/LuckPerms/assets/40437205/2c3eae72-d345-40d2-81ab-60ee0adb64dc)

Closes #3807 