### PR TITLE
Add modifyTrack to TrackManager

### DIFF
--- a/api/src/main/java/net/luckperms/api/track/TrackManager.java
+++ b/api/src/main/java/net/luckperms/api/track/TrackManager.java
@@ -97,6 +97,27 @@ public interface TrackManager {
     @NonNull CompletableFuture<Void> deleteTrack(@NonNull Track track);
 
     /**
+     * Loads (or creates) a track from the plugin's storage provider, applies the given {@code action},
+     * then saves the track's data back to storage.
+     *
+     * <p>This method effectively calls {@link #createAndLoadTrack(String)}, followed by the
+     * {@code action}, then {@link #saveTrack(Track)}, and returns an encapsulation of the whole
+     * process as a {@link CompletableFuture}. </p>
+     *
+     * @param name the name of the track
+     * @param action the action to apply to the track
+     * @return a future to encapsulate the operation
+     * @since 5.5
+     */
+    default @NonNull CompletableFuture<Void> modifyTrack(@NonNull String name, @NonNull Consumer<? super Track> action) {
+        /* This default method is overridden in the implementation, and is just here
+           to demonstrate what this method does in the API sources. */
+        return createAndLoadTrack(name)
+                .thenApplyAsync(track -> { action.accept(track); return track; })
+                .thenCompose(this::saveTrack);
+    }
+
+    /**
      * Loads all tracks into memory.
      *
      * @return a future to encapsulate the operation.


### PR DESCRIPTION
The UserManager and GroupManager both have a convenience method for loading and saving a user or a group after applying a modification. The TrackManager lacks this operation, despite also being modifiable and needing to be saved. I see this as a small hole in the API.

This PR adds a modifyTrack method to TrackManager, very closely modeled after modifyGroup.

I am making this PR because I found myself wanting this method, and it provides symmetry in the API.