### PR TITLE
Don’t read permission nodes twice for users

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/storage/implementation/sql/SqlStorage.java
+++ b/common/src/main/java/me/lucko/luckperms/common/storage/implementation/sql/SqlStorage.java
@@ -874,7 +874,7 @@ public class SqlStorage implements StorageImplementation {
                 while (rs.next()) {
                     Node node = readNode(rs);
                     if (node != null) {
-                        nodes.add(readNode(rs));
+                        nodes.add(node);
                     }
                 }
             }


### PR DESCRIPTION
After analyzing the code on the SqlStorage, I found that line of code when selecting user permission nodes.

After checking again, I came to the conclusion that reading the node again was unnecessary and wouldn’t affect the behavior.