### PR TITLE
fix: Environmental variables logging mongodb secrets

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
@@ -762,7 +762,8 @@ public final class ConfigKeys {
      * @return true if the value should be censored
      */
     public static boolean shouldCensorValue(final String path) {
-        return path.contains("password") || path.contains("uri");
+        final String lower = path.toLowerCase(Locale.ROOT);
+        return lower.contains("password") || lower.contains("uri");
     }
 
 }


### PR DESCRIPTION
Fixes #3850.

Caused by this from I believe a previous luckperms config version? https://github.com/LuckPerms/LuckPerms/blob/8c6586f008fb567a0b396df2b0fbc3c7093441d5/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java#L580

Another fix could be to remove the old config path