### PR TITLE
Set mappings namespace to skip remapping on Paper 1.20.5+

### DIFF
--- a/bukkit/loader/build.gradle
+++ b/bukkit/loader/build.gradle
@@ -25,6 +25,10 @@ shadowJar {
     from {
         project(':bukkit').tasks.shadowJar.archiveFile
     }
+
+    manifest {
+        attributes(["paperweight-mappings-namespace": "mojang"])
+    }
 }
 
 artifacts {


### PR DESCRIPTION
Remap is not needed since we don't use any non-reflection NMS (or NMS in general, afaik).