### PR TITLE
Fix login configuration phase being blocked by un-ACK-ed configuration task on NeoForge

### DIFF
--- a/neoforge/src/main/java/me/lucko/luckperms/neoforge/listeners/NeoForgeConnectionListener.java
+++ b/neoforge/src/main/java/me/lucko/luckperms/neoforge/listeners/NeoForgeConnectionListener.java
@@ -81,7 +81,7 @@ public class NeoForgeConnectionListener extends AbstractConnectionListener {
 
         event.register(new AsyncConfigurationTask(this.plugin, USER_LOGIN_TASK_TYPE, () -> CompletableFuture.runAsync(() -> {
             onPlayerNegotiationAsync(event.getListener().getConnection(), uniqueId, username);
-        }, this.plugin.getBootstrap().getScheduler().async())));
+        }, this.plugin.getBootstrap().getScheduler().async()), event.getListener()));
     }
 
     private void onPlayerNegotiationAsync(Connection connection, UUID uniqueId, String username) {

--- a/neoforge/src/main/java/me/lucko/luckperms/neoforge/util/AsyncConfigurationTask.java
+++ b/neoforge/src/main/java/me/lucko/luckperms/neoforge/util/AsyncConfigurationTask.java
@@ -27,6 +27,7 @@ package me.lucko.luckperms.neoforge.util;
 
 import me.lucko.luckperms.neoforge.LPNeoForgePlugin;
 import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.configuration.ServerConfigurationPacketListener;
 import net.minecraft.server.network.ConfigurationTask;
 
 import java.util.concurrent.CompletableFuture;
@@ -37,11 +38,13 @@ public class AsyncConfigurationTask implements ConfigurationTask {
     private final LPNeoForgePlugin plugin;
     private final Type type;
     private final Supplier<CompletableFuture<?>> task;
+    private final ServerConfigurationPacketListener listener;
 
-    public AsyncConfigurationTask(LPNeoForgePlugin plugin, Type type, Supplier<CompletableFuture<?>> task) {
+    public AsyncConfigurationTask(LPNeoForgePlugin plugin, Type type, Supplier<CompletableFuture<?>> task, ServerConfigurationPacketListener listener) {
         this.plugin = plugin;
         this.type = type;
         this.task = task;
+        this.listener = listener;
     }
 
     @Override
@@ -52,6 +55,9 @@ public class AsyncConfigurationTask implements ConfigurationTask {
                 this.plugin.getLogger().warn("Configuration task threw an exception", e);
             }
         }).join();
+        // NeoForge: Notify Minecraft that we are done, and you can move on to next configuration task,
+        // so that the login process won't stall.
+        this.listener.finishCurrentTask(this.type);
     }
 
     @Override


### PR DESCRIPTION
According to NeoForge Documentation, section "Networking § Using Configuration Tasks":

> When the configuration is not acknowledged, then the server will wait forever, and the client will never join the game. So it is important to always acknowledge the configuration task, unless the configuration task failed, then you can disconnect the client.

As of now, LuckPerms never marks `USER_LOGIN_TASK_TYPE` as completed even if it actually finishes. This leads to client hanging on login, as server was mistakenly waiting for a acknowledgement from client which never happens.

This PR slightly modifies the `AsyncConfigurationTask` so that it will "acknowledge" the configuration task on its own, as described in [NeoForge's own documentation](https://docs.neoforged.net/docs/networking/configuration-tasks#acknowledging-a-configuration-task).

This closes #3960.

