### PR TITLE
NeoForge: Migrate UserCapability to use Data Attachment API

### DIFF
--- a/neoforge/loader/src/main/java/me/lucko/luckperms/neoforge/loader/NeoForgeLoaderPlugin.java
+++ b/neoforge/loader/src/main/java/me/lucko/luckperms/neoforge/loader/NeoForgeLoaderPlugin.java
@@ -32,9 +32,11 @@ import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.fml.loading.FMLEnvironment;
+import net.neoforged.neoforge.registries.RegisterEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 @Mod(value = "luckperms")
@@ -59,6 +61,12 @@ public class NeoForgeLoaderPlugin implements Supplier<ModContainer> {
 
         this.loader = new JarInJarClassLoader(getClass().getClassLoader(), JAR_NAME);
         modBus.addListener(this::onCommonSetup);
+
+        try {
+            modBus.addListener((Consumer<RegisterEvent>)this.loader.loadClass("me.lucko.luckperms.neoforge.attachments.UserAttachmentRegister").newInstance());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/neoforge/neoforge-api/src/main/java/me/lucko/luckperms/neoforge/attachments/UserAttachment.java
+++ b/neoforge/neoforge-api/src/main/java/me/lucko/luckperms/neoforge/attachments/UserAttachment.java
@@ -23,28 +23,30 @@
  *  SOFTWARE.
  */
 
-package me.lucko.luckperms.neoforge.capabilities;
+package me.lucko.luckperms.neoforge.attachments;
 
 import net.luckperms.api.query.QueryOptions;
 import net.luckperms.api.util.Tristate;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
-import net.neoforged.neoforge.capabilities.EntityCapability;
+import net.neoforged.neoforge.attachment.AttachmentType;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
 
 /**
- * A NeoForge {@link EntityCapability} that attaches LuckPerms functionality onto {@link ServerPlayer}s.
+ * A NeoForge {@link AttachmentType Data Attachment} that attaches LuckPerms functionality onto {@link ServerPlayer}s.
  */
-public interface UserCapability {
+public interface UserAttachment {
 
     /**
-     * The identifier used for the capability
+     * The identifier used for the attachment
      */
     ResourceLocation IDENTIFIER = ResourceLocation.fromNamespaceAndPath("luckperms", "user");
 
     /**
-     * The capability instance.
+     * The attachment type instance; used for querying the actual {@link UserAttachment} instance.
      */
-    EntityCapability<UserCapability, Void> CAPABILITY = EntityCapability.createVoid(IDENTIFIER, UserCapability.class);
+    DeferredHolder<AttachmentType<?>, AttachmentType<UserAttachment>> TYPE = DeferredHolder.create(NeoForgeRegistries.Keys.ATTACHMENT_TYPES, IDENTIFIER);
 
     /**
      * Checks for a permission.

--- a/neoforge/src/main/java/me/lucko/luckperms/neoforge/LPNeoForgePlugin.java
+++ b/neoforge/src/main/java/me/lucko/luckperms/neoforge/LPNeoForgePlugin.java
@@ -41,7 +41,7 @@ import me.lucko.luckperms.common.plugin.AbstractLuckPermsPlugin;
 import me.lucko.luckperms.common.sender.DummyConsoleSender;
 import me.lucko.luckperms.common.sender.Sender;
 import me.lucko.luckperms.neoforge.calculator.NeoForgeCalculatorFactory;
-import me.lucko.luckperms.neoforge.capabilities.UserCapabilityListener;
+import me.lucko.luckperms.neoforge.attachments.UserAttachmentListener;
 import me.lucko.luckperms.neoforge.context.NeoForgeContextManager;
 import me.lucko.luckperms.neoforge.context.NeoForgePlayerCalculator;
 import me.lucko.luckperms.neoforge.listeners.NeoForgeAutoOpListener;
@@ -93,8 +93,8 @@ public class LPNeoForgePlugin extends AbstractLuckPermsPlugin {
         NeoForgePlatformListener platformListener = new NeoForgePlatformListener(this);
         this.bootstrap.registerListeners(platformListener);
 
-        UserCapabilityListener userCapabilityListener = new UserCapabilityListener();
-        this.bootstrap.registerListeners(userCapabilityListener);
+        UserAttachmentListener userAttachmentListener = new UserAttachmentListener();
+        this.bootstrap.registerListeners(userAttachmentListener);
 
         NeoForgePermissionHandlerListener permissionHandlerListener = new NeoForgePermissionHandlerListener(this);
         this.bootstrap.registerListeners(permissionHandlerListener);

--- a/neoforge/src/main/java/me/lucko/luckperms/neoforge/NeoForgeSenderFactory.java
+++ b/neoforge/src/main/java/me/lucko/luckperms/neoforge/NeoForgeSenderFactory.java
@@ -33,8 +33,8 @@ import me.lucko.luckperms.common.sender.Sender;
 import me.lucko.luckperms.common.sender.SenderFactory;
 import me.lucko.luckperms.common.verbose.VerboseCheckTarget;
 import me.lucko.luckperms.common.verbose.event.CheckOrigin;
-import me.lucko.luckperms.neoforge.capabilities.UserCapability;
-import me.lucko.luckperms.neoforge.capabilities.UserCapabilityImpl;
+import me.lucko.luckperms.neoforge.attachments.UserAttachment;
+import me.lucko.luckperms.neoforge.attachments.UserAttachmentImpl;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.luckperms.api.util.Tristate;
@@ -75,7 +75,7 @@ public class NeoForgeSenderFactory extends SenderFactory<LPNeoForgePlugin, Comma
         Locale locale;
         if (sender.getEntity() instanceof ServerPlayer) {
             ServerPlayer player = (ServerPlayer) sender.getEntity();
-            UserCapabilityImpl user = UserCapabilityImpl.get(player);
+            UserAttachmentImpl user = UserAttachmentImpl.get(player);
             locale = user.getLocale(player);
         } else {
             locale = null;
@@ -88,7 +88,7 @@ public class NeoForgeSenderFactory extends SenderFactory<LPNeoForgePlugin, Comma
     protected Tristate getPermissionValue(CommandSourceStack commandSource, String node) {
         if (commandSource.getEntity() instanceof ServerPlayer) {
             ServerPlayer player = (ServerPlayer) commandSource.getEntity();
-            UserCapability user = UserCapabilityImpl.get(player);
+            UserAttachment user = UserAttachmentImpl.get(player);
             return user.checkPermission(node);
         }
 

--- a/neoforge/src/main/java/me/lucko/luckperms/neoforge/attachments/UserAttachmentImpl.java
+++ b/neoforge/src/main/java/me/lucko/luckperms/neoforge/attachments/UserAttachmentImpl.java
@@ -23,7 +23,7 @@
  *  SOFTWARE.
  */
 
-package me.lucko.luckperms.neoforge.capabilities;
+package me.lucko.luckperms.neoforge.attachments;
 
 import java.util.Optional;
 import me.lucko.luckperms.common.cacheddata.type.PermissionCache;
@@ -41,30 +41,35 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 
-public class UserCapabilityImpl implements UserCapability {
+public class UserAttachmentImpl implements UserAttachment {
 
-    private static Optional<UserCapability> getCapability(Player player) {
-        return Optional.ofNullable(player.getCapability(CAPABILITY));
+    private static Optional<UserAttachment> getUserAttachment(Player player) {
+        if (player instanceof ServerPlayer) {
+            // getData() will create and cache a new instance using our factory method.
+            // Therefore, this return value should never be null.
+            return Optional.of(player.getData(UserAttachment.TYPE));
+        }
+        return Optional.empty();
     }
 
     /**
-     * Gets a {@link UserCapability} for a given {@link ServerPlayer}.
+     * Gets a {@link UserAttachment} for a given {@link ServerPlayer}.
      *
      * @param player the player
      * @return the capability
      */
-    public static @NotNull UserCapabilityImpl get(@NotNull Player player) {
-        return (UserCapabilityImpl) getCapability(player).orElseThrow(() -> new IllegalStateException("Capability missing for " + player.getUUID()));
+    public static @NotNull UserAttachmentImpl get(@NotNull Player player) {
+        return (UserAttachmentImpl) getUserAttachment(player).orElseThrow(() -> new IllegalStateException("Attachment missing for " + player.getUUID()));
     }
 
     /**
-     * Gets a {@link UserCapability} for a given {@link ServerPlayer}.
+     * Gets a {@link UserAttachment} for a given {@link ServerPlayer}.
      *
      * @param player the player
      * @return the capability, or null
      */
-    public static @Nullable UserCapabilityImpl getNullable(@NotNull Player player) {
-        return (UserCapabilityImpl) getCapability(player).orElse(null);
+    public static @Nullable UserAttachmentImpl getNullable(@NotNull Player player) {
+        return (UserAttachmentImpl) getUserAttachment(player).orElse(null);
     }
 
     private boolean initialised = false;
@@ -75,11 +80,11 @@ public class UserCapabilityImpl implements UserCapability {
     private String language;
     private Locale locale;
 
-    public UserCapabilityImpl() {
+    public UserAttachmentImpl() {
 
     }
 
-    public void initialise(UserCapabilityImpl previous) {
+    public void initialise(UserAttachmentImpl previous) {
         this.user = previous.user;
         this.queryOptionsCache = previous.queryOptionsCache;
         this.language = previous.language;

--- a/neoforge/src/main/java/me/lucko/luckperms/neoforge/attachments/UserAttachmentListener.java
+++ b/neoforge/src/main/java/me/lucko/luckperms/neoforge/attachments/UserAttachmentListener.java
@@ -23,31 +23,13 @@
  *  SOFTWARE.
  */
 
-package me.lucko.luckperms.neoforge.capabilities;
+package me.lucko.luckperms.neoforge.attachments;
 
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.player.Player;
 import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 
-public class UserCapabilityListener {
-
-    @SubscribeEvent
-    public void onRegisterCapabilities(RegisterCapabilitiesEvent event) {
-        event.registerEntity(
-                UserCapability.CAPABILITY,
-                EntityType.PLAYER,
-                (player, ctx) -> {
-                    if (!(player instanceof ServerPlayer)) {
-                        // Don't attach to LocalPlayer
-                        return null;
-                    }
-                    return new UserCapabilityImpl();
-                }
-        );
-    }
+public class UserAttachmentListener {
 
     @SubscribeEvent
     public void onPlayerClone(PlayerEvent.Clone event) {
@@ -55,8 +37,8 @@ public class UserCapabilityListener {
         Player currentPlayer = event.getEntity();
 
         try {
-            UserCapabilityImpl previous = UserCapabilityImpl.get(previousPlayer);
-            UserCapabilityImpl current = UserCapabilityImpl.get(currentPlayer);
+            UserAttachmentImpl previous = UserAttachmentImpl.get(previousPlayer);
+            UserAttachmentImpl current = UserAttachmentImpl.get(currentPlayer);
 
             current.initialise(previous);
             previous.invalidate();

--- a/neoforge/src/main/java/me/lucko/luckperms/neoforge/attachments/UserAttachmentRegister.java
+++ b/neoforge/src/main/java/me/lucko/luckperms/neoforge/attachments/UserAttachmentRegister.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of LuckPerms, licensed under the MIT License.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+package me.lucko.luckperms.neoforge.attachments;
+
+import net.neoforged.neoforge.attachment.AttachmentType;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
+import net.neoforged.neoforge.registries.RegisterEvent;
+
+import java.util.function.Consumer;
+
+public final class UserAttachmentRegister implements Consumer<RegisterEvent> {
+    @Override
+    public void accept(RegisterEvent event) {
+        if (event.getRegistryKey() == NeoForgeRegistries.Keys.ATTACHMENT_TYPES) {
+            /*
+             * Register our attachment type.
+             * Our attachment does not need serialisation, so we do not call serialize(...) here.
+             * copyOnDeath(), copyHandler() are also for serialisable attachments only, so we do not use them.
+             * Non-serialisable attachments are safe for server-only mods.
+             * Attachments are lazily evaluated; they are not created until first getData() call.
+             * One pitfall is that, you can call getData(UserAttachment.TYPE) on all entities, or even non-entities.
+             * There are no wau to prevent creating UserAttachment on non-player.
+             * To avoid issue, we need to make sure we only ever call ServerPlayer.getData().
+             */
+            event.register(NeoForgeRegistries.Keys.ATTACHMENT_TYPES, UserAttachment.IDENTIFIER,
+                    () -> AttachmentType.<UserAttachment>builder(UserAttachmentImpl::new).build());
+        }
+    }
+}

--- a/neoforge/src/main/java/me/lucko/luckperms/neoforge/context/NeoForgeContextManager.java
+++ b/neoforge/src/main/java/me/lucko/luckperms/neoforge/context/NeoForgeContextManager.java
@@ -29,7 +29,7 @@ import me.lucko.luckperms.common.config.ConfigKeys;
 import me.lucko.luckperms.common.context.manager.ContextManager;
 import me.lucko.luckperms.common.context.manager.QueryOptionsCache;
 import me.lucko.luckperms.neoforge.LPNeoForgePlugin;
-import me.lucko.luckperms.neoforge.capabilities.UserCapabilityImpl;
+import me.lucko.luckperms.neoforge.attachments.UserAttachmentImpl;
 import net.luckperms.api.context.ImmutableContextSet;
 import net.luckperms.api.query.OptionKey;
 import net.luckperms.api.query.QueryOptions;
@@ -55,7 +55,7 @@ public class NeoForgeContextManager extends ContextManager<ServerPlayer, ServerP
             throw new NullPointerException("subject");
         }
 
-        return UserCapabilityImpl.get(subject).getQueryOptionsCache();
+        return UserAttachmentImpl.get(subject).getQueryOptionsCache();
     }
 
     @Override
@@ -70,7 +70,7 @@ public class NeoForgeContextManager extends ContextManager<ServerPlayer, ServerP
 
     @Override
     public void invalidateCache(ServerPlayer subject) {
-        UserCapabilityImpl capability = UserCapabilityImpl.getNullable(subject);
+        UserAttachmentImpl capability = UserAttachmentImpl.getNullable(subject);
         if (capability != null) {
             capability.getQueryOptionsCache().invalidate();
         }

--- a/neoforge/src/main/java/me/lucko/luckperms/neoforge/listeners/NeoForgeConnectionListener.java
+++ b/neoforge/src/main/java/me/lucko/luckperms/neoforge/listeners/NeoForgeConnectionListener.java
@@ -33,7 +33,7 @@ import me.lucko.luckperms.common.model.User;
 import me.lucko.luckperms.common.plugin.util.AbstractConnectionListener;
 import me.lucko.luckperms.neoforge.NeoForgeSenderFactory;
 import me.lucko.luckperms.neoforge.LPNeoForgePlugin;
-import me.lucko.luckperms.neoforge.capabilities.UserCapabilityImpl;
+import me.lucko.luckperms.neoforge.attachments.UserAttachmentImpl;
 import me.lucko.luckperms.neoforge.util.AsyncConfigurationTask;
 import net.kyori.adventure.text.Component;
 import net.minecraft.network.Connection;
@@ -44,7 +44,7 @@ import net.minecraft.server.network.ConfigurationTask;
 import net.minecraft.server.network.ServerConfigurationPacketListenerImpl;
 
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
+
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
@@ -148,7 +148,7 @@ public class NeoForgeConnectionListener extends AbstractConnectionListener {
         }
 
         // initialise capability
-        UserCapabilityImpl userCapability = UserCapabilityImpl.get(player);
+        UserAttachmentImpl userCapability = UserAttachmentImpl.get(player);
         userCapability.initialise(user, player, this.plugin.getContextManager());
         this.plugin.getContextManager().signalContextUpdate(player);
     }

--- a/neoforge/src/main/java/me/lucko/luckperms/neoforge/service/NeoForgePermissionHandler.java
+++ b/neoforge/src/main/java/me/lucko/luckperms/neoforge/service/NeoForgePermissionHandler.java
@@ -32,7 +32,7 @@ import me.lucko.luckperms.common.model.User;
 import me.lucko.luckperms.common.verbose.event.CheckOrigin;
 import me.lucko.luckperms.neoforge.LPNeoForgeBootstrap;
 import me.lucko.luckperms.neoforge.LPNeoForgePlugin;
-import me.lucko.luckperms.neoforge.capabilities.UserCapabilityImpl;
+import me.lucko.luckperms.neoforge.attachments.UserAttachmentImpl;
 import net.luckperms.api.context.ImmutableContextSet;
 import net.luckperms.api.query.QueryMode;
 import net.luckperms.api.query.QueryOptions;
@@ -78,7 +78,7 @@ public class NeoForgePermissionHandler implements IPermissionHandler {
 
     @Override
     public <T> T getPermission(ServerPlayer player, PermissionNode<T> node, PermissionDynamicContext<?>... context) {
-        UserCapabilityImpl capability = UserCapabilityImpl.getNullable(player);
+        UserAttachmentImpl capability = UserAttachmentImpl.getNullable(player);
 
         if (capability != null) {
             User user = capability.getUser();

--- a/neoforge/src/main/java/me/lucko/luckperms/neoforge/util/BrigadierInjector.java
+++ b/neoforge/src/main/java/me/lucko/luckperms/neoforge/util/BrigadierInjector.java
@@ -32,8 +32,8 @@ import me.lucko.luckperms.common.graph.Graph;
 import me.lucko.luckperms.common.graph.TraversalAlgorithm;
 import me.lucko.luckperms.common.model.User;
 import me.lucko.luckperms.neoforge.LPNeoForgePlugin;
-import me.lucko.luckperms.neoforge.capabilities.UserCapability;
-import me.lucko.luckperms.neoforge.capabilities.UserCapabilityImpl;
+import me.lucko.luckperms.neoforge.attachments.UserAttachment;
+import me.lucko.luckperms.neoforge.attachments.UserAttachmentImpl;
 import net.luckperms.api.util.Tristate;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.server.level.ServerPlayer;
@@ -152,7 +152,7 @@ public final class BrigadierInjector {
                     }
                     state = user.getCachedData().getPermissionData().checkPermission(permission);
                 } else {
-                    UserCapability user = UserCapabilityImpl.get(player);
+                    UserAttachment user = UserAttachmentImpl.get(player);
                     state = user.checkPermission(this.permission);
                 }
 


### PR DESCRIPTION
This would fix LuckPerms/LuckPerms#3963. I have built the jar on my own and tested locally; clients can join the server again now. 

However, I strongly believe that this is not the proper way to do it. In particular, to register a data attachment type, I must have to register a new listener to the `modBus` found in `NeoForgeLoaderPlugin` - which, requires ugly reflection at this moment. 

Thus I left this pull request as draft. Feedbacks are welcomed. 