### PR TITLE
Add missing IllegalArgumentExceptions to Javadocs

### DIFF
--- a/api/src/main/java/net/luckperms/api/node/types/DisplayNameNode.java
+++ b/api/src/main/java/net/luckperms/api/node/types/DisplayNameNode.java
@@ -63,6 +63,7 @@ public interface DisplayNameNode extends ScopedNode<DisplayNameNode, DisplayName
      *
      * @param displayName the display name to set
      * @return the builder
+     * @throws IllegalArgumentException if {@code displayName} is empty
      */
     static @NonNull Builder builder(@NonNull String displayName) {
         return builder().displayName(displayName);

--- a/api/src/main/java/net/luckperms/api/node/types/InheritanceNode.java
+++ b/api/src/main/java/net/luckperms/api/node/types/InheritanceNode.java
@@ -67,6 +67,7 @@ public interface InheritanceNode extends ScopedNode<InheritanceNode, Inheritance
      *
      * @param group the group to set
      * @return the builder
+     * @throws IllegalArgumentException if {@code group} is not a valid group name
      */
     static @NonNull Builder builder(@NonNull String group) {
         return builder().group(group);

--- a/api/src/main/java/net/luckperms/api/node/types/MetaNode.java
+++ b/api/src/main/java/net/luckperms/api/node/types/MetaNode.java
@@ -71,6 +71,7 @@ public interface MetaNode extends ScopedNode<MetaNode, MetaNode.Builder> {
      * @param key the meta key to set
      * @param value the meta value to set
      * @return the builder
+     * @throws IllegalArgumentException if {@code key} is empty
      */
     static @NonNull Builder builder(@NonNull String key, @NonNull String value) {
         return builder().key(key).value(value);

--- a/api/src/main/java/net/luckperms/api/node/types/PermissionNode.java
+++ b/api/src/main/java/net/luckperms/api/node/types/PermissionNode.java
@@ -88,6 +88,7 @@ public interface PermissionNode extends ScopedNode<PermissionNode, PermissionNod
      *
      * @param permission the permission to set
      * @return the builder
+     * @throws IllegalArgumentException if {@code permission} is empty
      */
     static @NonNull Builder builder(@NonNull String permission) {
         return builder().permission(permission);

--- a/api/src/main/java/net/luckperms/api/node/types/RegexPermissionNode.java
+++ b/api/src/main/java/net/luckperms/api/node/types/RegexPermissionNode.java
@@ -75,6 +75,7 @@ public interface RegexPermissionNode extends ScopedNode<RegexPermissionNode, Reg
      *
      * @param pattern the pattern to set
      * @return the builder
+     * @throws IllegalArgumentException if {@code pattern} is empty
      */
     static @NonNull Builder builder(@NonNull String pattern) {
         return builder().pattern(pattern);


### PR DESCRIPTION
#3606 has improved handling of empty inputs by `NodeBuilder`s, but forgot to add `IllegalArgumentException`s for static builder methods of node classes.