### PR TITLE
Add fabric console permission bypass

### DIFF
--- a/fabric/src/main/java/me/lucko/luckperms/fabric/FabricSenderFactory.java
+++ b/fabric/src/main/java/me/lucko/luckperms/fabric/FabricSenderFactory.java
@@ -58,19 +58,18 @@ public class FabricSenderFactory extends SenderFactory<LPFabricPlugin, ServerCom
 
     @Override
     protected UUID getUniqueId(ServerCommandSource commandSource) {
-        if (commandSource.getEntity() != null) {
-            return commandSource.getEntity().getUuid();
+        if (isConsole(commandSource) || commandSource.getEntity() != null) {
+            return Sender.CONSOLE_UUID;
         }
-        return Sender.CONSOLE_UUID;
+        return commandSource.getEntity().getUuid();
     }
 
     @Override
     protected String getName(ServerCommandSource commandSource) {
-        String name = commandSource.getName();
-        if (commandSource.getEntity() != null && name.equals("Server")) {
+        if (isConsole(commandSource)) {
             return Sender.CONSOLE_NAME;
         }
-        return name;
+        return commandSource.getName();
     }
 
     @Override


### PR DESCRIPTION
Currently consoles on fabric (and presumably forge, neoforge) can't execute commands that require a permission and don't use an operator fallback.

This is an initial draft for a console bypass *(console always has all permissions)* on fabric. I am not sure on the specifics of the verbose check event, let me know what you think! If this approach seems fine, it should be easy to port these changes to forge and neoforge.