### PR TITLE
Config option to combine existing nodes on import with new nodes of same key, value, & expiry

### DIFF
--- a/api/src/main/java/net/luckperms/api/node/NodeEqualityPredicate.java
+++ b/api/src/main/java/net/luckperms/api/node/NodeEqualityPredicate.java
@@ -156,4 +156,16 @@ public interface NodeEqualityPredicate {
      */
     NodeEqualityPredicate IGNORE_VALUE_OR_IF_TEMPORARY = new DummyNodeEqualityPredicate("IGNORE_VALUE_OR_IF_TEMPORARY");
 
+    /**
+     * All attributes must match, except for the {@link Node#getContexts() context}, which is ignored.
+     * 
+     * <p>Returns true if: (and)</p>
+     * <p></p>
+     * <ul>
+     * <li>{@link Node#getKey() key} = key</li>
+     * <li>{@link Node#getValue() value} = value</li>
+     * <li>{@link Node#getExpiry() expiry} = expiry</li>
+     * </ul>
+     */
+    NodeEqualityPredicate IGNORE_CONTEXT = new DummyNodeEqualityPredicate("IGNORE_CONTEXT");
 }

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -719,3 +719,10 @@ register-command-list-data: true
 # If LuckPerms should attempt to resolve Vanilla command target selectors for LP commands.
 # See here for more info: https://minecraft.wiki/w/Target_selectors
 resolve-command-selectors: false
+
+# If LuckPerms should attempt to merge into existing permission nodes when importing data when the 
+# effective result would be the same.
+#
+# - Useful if you are importing data from multiple sources with overlapping permissions.
+# - Note that this will cause the import process to be slower.
+use-existing-node-entries-on-import: false

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -611,3 +611,10 @@ disable-bulkupdate: false
 #
 # - When this happens, the plugin will set their primary group back to default.
 prevent-primary-group-removal: false
+
+# If LuckPerms should attempt to merge into existing permission nodes when importing data when the 
+# effective result would be the same.
+#
+# - Useful if you are importing data from multiple sources with overlapping permissions.
+# - Note that this will cause the import process to be slower.
+use-existing-node-entries-on-import: false

--- a/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
@@ -163,6 +163,12 @@ public final class ConfigKeys {
     public static final ConfigKey<Boolean> DISABLE_BULKUPDATE = booleanKey("disable-bulkupdate", false);
 
     /**
+     * If LuckPerms should attempt to merge into existing permission nodes when importing data when the effective result would be the same.
+     * If this is false, the plugin will always create new permission nodes for each entry in the import data.
+     */
+    public static final ConfigKey<Boolean> USE_EXISTING_NODE_ENTRIES_ON_IMPORT = booleanKey("use-existing-node-entries-on-import", false);
+
+    /**
      * If LuckPerms should produce extra logging output when it handles logins.
      */
     public static final ConfigKey<Boolean> DEBUG_LOGINS = booleanKey("debug-logins", false);

--- a/common/src/main/java/me/lucko/luckperms/common/model/PermissionHolder.java
+++ b/common/src/main/java/me/lucko/luckperms/common/model/PermissionHolder.java
@@ -25,6 +25,7 @@
 
 package me.lucko.luckperms.common.model;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import me.lucko.luckperms.common.cacheddata.HolderCachedDataManager;
 import me.lucko.luckperms.common.cacheddata.result.IntegerResult;
@@ -45,6 +46,7 @@ import net.luckperms.api.model.data.DataMutateResult;
 import net.luckperms.api.model.data.DataType;
 import net.luckperms.api.model.data.TemporaryNodeMergeStrategy;
 import net.luckperms.api.node.Node;
+import net.luckperms.api.node.NodeBuilder;
 import net.luckperms.api.node.NodeEqualityPredicate;
 import net.luckperms.api.node.NodeType;
 import net.luckperms.api.node.types.InheritanceNode;
@@ -60,10 +62,12 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.OptionalInt;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.IntFunction;
@@ -241,6 +245,29 @@ public abstract class PermissionHolder {
     }
 
     public void mergeNodes(DataType type, Iterable<? extends Node> set) {
+        getData(type).addAll(set);
+        invalidateCache();
+    }
+
+    public void deepMergeNodes(DataType type, Set<Node> set) {
+        ImmutableSet<Node> existingData = getData(type).asImmutableSet();
+        for (Node existing : existingData) {
+            Set<Node> toCombine = new HashSet<>();
+            for (Node node : set) {
+                if (existing.equals(node, NodeEqualityPredicate.IGNORE_CONTEXT)) {
+                    toCombine.add(node);
+                }
+            }
+            if (toCombine.isEmpty()) {
+                continue;
+            }
+            NodeBuilder<?, ?> combined = existing.toBuilder();
+            for (Node node : toCombine) {
+                combined.withContext(node.getContexts());
+            }
+            getData(type).removeThenAdd(existing, combined.build());
+            set.removeAll(toCombine);
+        }
         getData(type).addAll(set);
         invalidateCache();
     }

--- a/common/src/main/java/me/lucko/luckperms/common/node/NodeEquality.java
+++ b/common/src/main/java/me/lucko/luckperms/common/node/NodeEquality.java
@@ -38,6 +38,15 @@ public enum NodeEquality {
                     o1.getContexts().equals(o2.getContexts());
         }
     },
+    KEY_VALUE_EXPIRY {
+        @Override
+        public boolean equals(AbstractNode<?, ?> o1, AbstractNode<?, ?> o2) {
+            return o1 == o2 ||
+                    o1.key.equals(o2.key) &&
+                    o1.value == o2.value &&
+                    o1.expireAt == o2.expireAt;
+        }
+    },
     KEY_EXPIRY_CONTEXTS {
         @Override
         public boolean equals(AbstractNode<?, ?> o1, AbstractNode<?, ?> o2) {
@@ -101,6 +110,8 @@ public enum NodeEquality {
             return NodeEquality.KEY_CONTEXTS;
         } else if (equalityPredicate == NodeEqualityPredicate.ONLY_KEY) {
             return NodeEquality.KEY;
+        } else if (equalityPredicate == NodeEqualityPredicate.IGNORE_CONTEXT) {
+            return NodeEquality.KEY_VALUE_EXPIRY;
         } else {
             return null;
         }

--- a/fabric/src/main/resources/luckperms.conf
+++ b/fabric/src/main/resources/luckperms.conf
@@ -650,3 +650,10 @@ update-client-command-list = true
 # If LuckPerms should attempt to resolve Vanilla command target selectors for LP commands.
 # See here for more info: https://minecraft.wiki/w/Target_selectors
 resolve-command-selectors = false
+
+# If LuckPerms should attempt to merge into existing permission nodes when importing data when the 
+# effective result would be the same.
+#
+# - Useful if you are importing data from multiple sources with overlapping permissions.
+# - Note that this will cause the import process to be slower.
+use-existing-node-entries-on-import = false

--- a/forge/src/main/resources/luckperms.conf
+++ b/forge/src/main/resources/luckperms.conf
@@ -639,3 +639,10 @@ update-client-command-list = true
 # If LuckPerms should attempt to resolve Vanilla command target selectors for LP commands.
 # See here for more info: https://minecraft.wiki/w/Target_selectors
 resolve-command-selectors = false
+
+# If LuckPerms should attempt to merge into existing permission nodes when importing data when the 
+# effective result would be the same.
+#
+# - Useful if you are importing data from multiple sources with overlapping permissions.
+# - Note that this will cause the import process to be slower.
+use-existing-node-entries-on-import = false

--- a/neoforge/src/main/resources/luckperms.conf
+++ b/neoforge/src/main/resources/luckperms.conf
@@ -639,3 +639,10 @@ update-client-command-list = true
 # If LuckPerms should attempt to resolve Vanilla command target selectors for LP commands.
 # See here for more info: https://minecraft.wiki/w/Target_selectors
 resolve-command-selectors = false
+
+# If LuckPerms should attempt to merge into existing permission nodes when importing data when the 
+# effective result would be the same.
+#
+# - Useful if you are importing data from multiple sources with overlapping permissions.
+# - Note that this will cause the import process to be slower.
+use-existing-node-entries-on-import = false

--- a/nukkit/src/main/resources/config.yml
+++ b/nukkit/src/main/resources/config.yml
@@ -653,3 +653,10 @@ disable-bulkupdate: false
 #
 # - When this happens, the plugin will set their primary group back to default.
 prevent-primary-group-removal: false
+
+# If LuckPerms should attempt to merge into existing permission nodes when importing data when the 
+# effective result would be the same.
+#
+# - Useful if you are importing data from multiple sources with overlapping permissions.
+# - Note that this will cause the import process to be slower.
+use-existing-node-entries-on-import: false

--- a/sponge/src/main/resources/luckperms.conf
+++ b/sponge/src/main/resources/luckperms.conf
@@ -637,3 +637,10 @@ update-client-command-list = true
 # If LuckPerms should attempt to resolve Vanilla command target selectors for LP commands.
 # See here for more info: https://minecraft.wiki/w/Target_selectors
 resolve-command-selectors = false
+
+# If LuckPerms should attempt to merge into existing permission nodes when importing data when the 
+# effective result would be the same.
+#
+# - Useful if you are importing data from multiple sources with overlapping permissions.
+# - Note that this will cause the import process to be slower.
+use-existing-node-entries-on-import = false

--- a/standalone/src/main/resources/config.yml
+++ b/standalone/src/main/resources/config.yml
@@ -576,3 +576,10 @@ disable-bulkupdate: false
 #
 # - When this happens, the plugin will set their primary group back to default.
 prevent-primary-group-removal: false
+
+# If LuckPerms should attempt to merge into existing permission nodes when importing data when the 
+# effective result would be the same.
+#
+# - Useful if you are importing data from multiple sources with overlapping permissions.
+# - Note that this will cause the import process to be slower.
+use-existing-node-entries-on-import: false

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -597,3 +597,10 @@ disable-bulkupdate: false
 #
 # - When this happens, the plugin will set their primary group back to default.
 prevent-primary-group-removal: false
+
+# If LuckPerms should attempt to merge into existing permission nodes when importing data when the 
+# effective result would be the same.
+#
+# - Useful if you are importing data from multiple sources with overlapping permissions.
+# - Note that this will cause the import process to be slower.
+use-existing-node-entries-on-import: false


### PR DESCRIPTION
Related to https://github.com/LuckPerms/LuckPerms/pull/4040

Adds a config option (default `false`) to merge existing node entries when using the import command. This results in a much cleaner permissions set when there are overlapping nodes due to different contexts.

Usage:
```yaml
# If LuckPerms should attempt to merge into existing permission nodes when importing data when the 
# effective result would be the same.
#
# - Useful if you are importing data from multiple sources with overlapping permissions.
# - Note that this will cause the import process to be slower.
use-existing-node-entries-on-import: false
```