### PR TITLE
Improve context manager caching

### DIFF
--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/inject/permissible/LuckPermsPermissible.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/inject/permissible/LuckPermsPermissible.java
@@ -32,7 +32,7 @@ import me.lucko.luckperms.bukkit.calculator.OpProcessor;
 import me.lucko.luckperms.bukkit.calculator.PermissionMapProcessor;
 import me.lucko.luckperms.common.cacheddata.result.TristateResult;
 import me.lucko.luckperms.common.config.ConfigKeys;
-import me.lucko.luckperms.common.context.manager.QueryOptionsCache;
+import me.lucko.luckperms.common.context.manager.QueryOptionsSupplier;
 import me.lucko.luckperms.common.model.User;
 import me.lucko.luckperms.common.verbose.event.CheckOrigin;
 import net.luckperms.api.query.QueryOptions;
@@ -68,7 +68,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * "Hot" method calls, (namely #hasPermission) are significantly faster than the base implementation.
  *
  * This class is **thread safe**. This means that when LuckPerms is installed on the server,
- * is is safe to call Player#hasPermission asynchronously.
+ * it is safe to call Player#hasPermission asynchronously.
  */
 public class LuckPermsPermissible extends PermissibleBase {
 
@@ -93,7 +93,7 @@ public class LuckPermsPermissible extends PermissibleBase {
     private final LPBukkitPlugin plugin;
 
     // caches context lookups for the player
-    private final QueryOptionsCache<Player> queryOptionsSupplier;
+    private final QueryOptionsSupplier queryOptionsSupplier;
 
     // the players previous permissible. (the one they had before this one was injected)
     private PermissibleBase oldPermissible = null;
@@ -110,7 +110,7 @@ public class LuckPermsPermissible extends PermissibleBase {
         this.user = Objects.requireNonNull(user, "user");
         this.player = Objects.requireNonNull(player, "player");
         this.plugin = Objects.requireNonNull(plugin, "plugin");
-        this.queryOptionsSupplier = plugin.getContextManager().getCacheFor(player);
+        this.queryOptionsSupplier = plugin.getContextManager().createQueryOptionsSupplier(player);
 
         injectFakeAttachmentsList();
     }
@@ -293,7 +293,7 @@ public class LuckPermsPermissible extends PermissibleBase {
         // the query options cache when op status changes.
         // (#invalidate is a fast call)
         if (this.queryOptionsSupplier != null) { // this method is called by the super class constructor, before this class has fully initialised
-            this.queryOptionsSupplier.invalidate();
+            this.queryOptionsSupplier.invalidateCache();
         }
 
         // but we don't need to do anything else in this method, unlike the CB impl.
@@ -314,6 +314,10 @@ public class LuckPermsPermissible extends PermissibleBase {
 
     public LPBukkitPlugin getPlugin() {
         return this.plugin;
+    }
+
+    public QueryOptionsSupplier getQueryOptionsSupplier() {
+        return this.queryOptionsSupplier;
     }
 
     PermissibleBase getOldPermissible() {
@@ -409,9 +413,7 @@ public class LuckPermsPermissible extends PermissibleBase {
         @Override public PermissionAttachment remove(int index) { throw new UnsupportedOperationException(); }
         @Override public int indexOf(Object o) { throw new UnsupportedOperationException(); }
         @Override public int lastIndexOf(Object o) { throw new UnsupportedOperationException(); }
-        @Override
-        public @NonNull ListIterator<PermissionAttachment> listIterator(int index) { throw new UnsupportedOperationException(); }
-        @Override
-        public @NonNull List<PermissionAttachment> subList(int fromIndex, int toIndex) { throw new UnsupportedOperationException(); }
+        @Override public @NonNull ListIterator<PermissionAttachment> listIterator(int index) { throw new UnsupportedOperationException(); }
+        @Override public @NonNull List<PermissionAttachment> subList(int fromIndex, int toIndex) { throw new UnsupportedOperationException(); }
     }
 }

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/inject/permissible/PermissibleInjector.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/inject/permissible/PermissibleInjector.java
@@ -30,6 +30,7 @@ import me.lucko.luckperms.common.plugin.logging.PluginLogger;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissibleBase;
 import org.bukkit.permissions.PermissionAttachment;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.lang.reflect.Field;
 import java.util.List;
@@ -159,6 +160,19 @@ public final class PermissibleInjector {
                 HUMAN_ENTITY_PERMISSIBLE_FIELD.set(player, newPb);
             }
         }
+    }
+
+    public static @Nullable LuckPermsPermissible get(Player player) {
+        PermissibleBase permissibleBase;
+        try {
+            permissibleBase = (PermissibleBase) HUMAN_ENTITY_PERMISSIBLE_FIELD.get(player);
+        } catch (IllegalAccessException e) {
+            return null;
+        }
+        if (permissibleBase instanceof LuckPermsPermissible) {
+            return (LuckPermsPermissible) permissibleBase;
+        }
+        return null;
     }
 
     public static void checkInjected(Player player, PluginLogger logger) {

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/listeners/BukkitConnectionListener.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/listeners/BukkitConnectionListener.java
@@ -253,9 +253,6 @@ public class BukkitConnectionListener extends AbstractConnectionListener impleme
             if (this.plugin.getConfiguration().get(ConfigKeys.AUTO_OP)) {
                 player.setOp(false);
             }
-
-            // remove their contexts cache
-            this.plugin.getContextManager().onPlayerQuit(player);
         }, 1L);
     }
 

--- a/bungee/src/main/java/me/lucko/luckperms/bungee/context/BungeeContextManager.java
+++ b/bungee/src/main/java/me/lucko/luckperms/bungee/context/BungeeContextManager.java
@@ -26,12 +26,12 @@
 package me.lucko.luckperms.bungee.context;
 
 import me.lucko.luckperms.bungee.LPBungeePlugin;
-import me.lucko.luckperms.common.context.manager.InlineContextManager;
+import me.lucko.luckperms.common.context.manager.SimpleContextManager;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
 import java.util.UUID;
 
-public class BungeeContextManager extends InlineContextManager<ProxiedPlayer, ProxiedPlayer> {
+public class BungeeContextManager extends SimpleContextManager<ProxiedPlayer, ProxiedPlayer> {
     public BungeeContextManager(LPBungeePlugin plugin) {
         super(plugin, ProxiedPlayer.class, ProxiedPlayer.class);
     }

--- a/common/src/main/java/me/lucko/luckperms/common/context/manager/DetachedContextManager.java
+++ b/common/src/main/java/me/lucko/luckperms/common/context/manager/DetachedContextManager.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of LuckPerms, licensed under the MIT License.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+package me.lucko.luckperms.common.context.manager;
+
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import me.lucko.luckperms.common.plugin.LuckPermsPlugin;
+import me.lucko.luckperms.common.util.CaffeineFactory;
+import net.luckperms.api.query.QueryOptions;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Implementation of {@link ContextManager} which utilises 'detached' supplier caches stored alongside the subject instances.
+ */
+public abstract class DetachedContextManager<S, P extends S> extends ContextManager<S, P> {
+
+    private final LoadingCache<S, QueryOptions> fallbackContextsCache = CaffeineFactory.newBuilder()
+            .expireAfterWrite(50, TimeUnit.MILLISECONDS)
+            .build(this::calculate);
+
+    protected DetachedContextManager(LuckPermsPlugin plugin, Class<S> subjectClass, Class<P> playerClass) {
+        super(plugin, subjectClass, playerClass);
+    }
+
+    @Override
+    public QueryOptions getQueryOptions(S subject) {
+        QueryOptionsSupplier supplier = getQueryOptionsSupplier(subject);
+        if (supplier != null) {
+            return supplier.getQueryOptions();
+        }
+        return this.fallbackContextsCache.get(subject);
+    }
+
+    @Override
+    public void invalidateCache(S subject) {
+        QueryOptionsSupplier queryOptionsSupplier = getQueryOptionsSupplier(subject);
+        if (queryOptionsSupplier != null) {
+            queryOptionsSupplier.invalidateCache();
+        }
+        this.fallbackContextsCache.invalidate(subject);
+    }
+
+    public QueryOptionsSupplier createQueryOptionsSupplier(S subject) {
+        return new QueryOptionsCache<>(subject, this);
+    }
+
+    public abstract @Nullable QueryOptionsSupplier getQueryOptionsSupplier(S subject);
+
+}

--- a/common/src/main/java/me/lucko/luckperms/common/context/manager/QueryOptionsCache.java
+++ b/common/src/main/java/me/lucko/luckperms/common/context/manager/QueryOptionsCache.java
@@ -37,11 +37,11 @@ import java.util.concurrent.TimeUnit;
  *
  * @param <T> the player type
  */
-public final class QueryOptionsCache<T> extends ExpiringCache<QueryOptions> implements QueryOptionsSupplier {
+final class QueryOptionsCache<T> extends ExpiringCache<QueryOptions> implements QueryOptionsSupplier {
     private final T subject;
     private final ContextManager<T, ?> contextManager;
 
-    public QueryOptionsCache(T subject, ContextManager<T, ?> contextManager) {
+    QueryOptionsCache(T subject, ContextManager<T, ?> contextManager) {
         super(50L, TimeUnit.MILLISECONDS); // expire roughly every tick
         this.subject = subject;
         this.contextManager = contextManager;
@@ -60,5 +60,10 @@ public final class QueryOptionsCache<T> extends ExpiringCache<QueryOptions> impl
     @Override
     public ImmutableContextSet getContextSet() {
         return get().context();
+    }
+
+    @Override
+    public void invalidateCache() {
+        invalidate();
     }
 }

--- a/common/src/main/java/me/lucko/luckperms/common/context/manager/QueryOptionsSupplier.java
+++ b/common/src/main/java/me/lucko/luckperms/common/context/manager/QueryOptionsSupplier.java
@@ -39,4 +39,6 @@ public interface QueryOptionsSupplier {
         return getQueryOptions().context();
     }
 
+    void invalidateCache();
+
 }

--- a/fabric/src/main/java/me/lucko/luckperms/fabric/mixin/ServerPlayerEntityMixin.java
+++ b/fabric/src/main/java/me/lucko/luckperms/fabric/mixin/ServerPlayerEntityMixin.java
@@ -27,7 +27,7 @@ package me.lucko.luckperms.fabric.mixin;
 
 import me.lucko.luckperms.common.cacheddata.type.MetaCache;
 import me.lucko.luckperms.common.cacheddata.type.PermissionCache;
-import me.lucko.luckperms.common.context.manager.QueryOptionsCache;
+import me.lucko.luckperms.common.context.manager.QueryOptionsSupplier;
 import me.lucko.luckperms.common.model.User;
 import me.lucko.luckperms.common.verbose.event.CheckOrigin;
 import me.lucko.luckperms.fabric.context.FabricContextManager;
@@ -61,7 +61,7 @@ public abstract class ServerPlayerEntityMixin implements MixinUser {
      * having to maintain a map of Player->Cache.
      */
     @Unique
-    private QueryOptionsCache<ServerPlayerEntity> luckperms$queryOptions;
+    private QueryOptionsSupplier luckperms$queryOptions;
 
     // Used by PlayerChangeWorldCallback hook below.
     @Shadow public abstract ServerWorld getServerWorld();
@@ -72,9 +72,9 @@ public abstract class ServerPlayerEntityMixin implements MixinUser {
     }
 
     @Override
-    public QueryOptionsCache<ServerPlayerEntity> luckperms$getQueryOptionsCache(FabricContextManager contextManager) {
+    public QueryOptionsSupplier luckperms$getQueryOptionsCache(FabricContextManager contextManager) {
         if (this.luckperms$queryOptions == null) {
-            this.luckperms$queryOptions = contextManager.newQueryOptionsCache((ServerPlayerEntity) (Object) this);
+            this.luckperms$queryOptions = contextManager.createQueryOptionsSupplier((ServerPlayerEntity) (Object) this);
         }
         return this.luckperms$queryOptions;
     }

--- a/fabric/src/main/java/me/lucko/luckperms/fabric/model/MixinUser.java
+++ b/fabric/src/main/java/me/lucko/luckperms/fabric/model/MixinUser.java
@@ -25,7 +25,7 @@
 
 package me.lucko.luckperms.fabric.model;
 
-import me.lucko.luckperms.common.context.manager.QueryOptionsCache;
+import me.lucko.luckperms.common.context.manager.QueryOptionsSupplier;
 import me.lucko.luckperms.common.model.User;
 import me.lucko.luckperms.fabric.context.FabricContextManager;
 import net.luckperms.api.query.QueryOptions;
@@ -41,12 +41,12 @@ public interface MixinUser {
     User luckperms$getUser();
 
     /**
-     * Gets (or creates using the manager) the objects {@link QueryOptionsCache}.
+     * Gets (or creates using the manager) the objects {@link QueryOptionsSupplier}.
      *
      * @param contextManager the contextManager
      * @return the cache
      */
-    QueryOptionsCache<ServerPlayerEntity> luckperms$getQueryOptionsCache(FabricContextManager contextManager);
+    QueryOptionsSupplier luckperms$getQueryOptionsCache(FabricContextManager contextManager);
 
     /**
      * Initialises permissions for this player using the given {@link User}.

--- a/forge/src/main/java/me/lucko/luckperms/forge/LPForgePlugin.java
+++ b/forge/src/main/java/me/lucko/luckperms/forge/LPForgePlugin.java
@@ -93,7 +93,7 @@ public class LPForgePlugin extends AbstractLuckPermsPlugin {
         ForgePlatformListener platformListener = new ForgePlatformListener(this);
         this.bootstrap.registerListeners(platformListener);
 
-        UserCapabilityListener userCapabilityListener = new UserCapabilityListener();
+        UserCapabilityListener userCapabilityListener = new UserCapabilityListener(this);
         this.bootstrap.registerListeners(userCapabilityListener);
 
         ForgePermissionHandlerListener permissionHandlerListener = new ForgePermissionHandlerListener(this);

--- a/forge/src/main/java/me/lucko/luckperms/forge/capabilities/UserCapabilityListener.java
+++ b/forge/src/main/java/me/lucko/luckperms/forge/capabilities/UserCapabilityListener.java
@@ -25,6 +25,7 @@
 
 package me.lucko.luckperms.forge.capabilities;
 
+import me.lucko.luckperms.forge.LPForgePlugin;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
@@ -40,6 +41,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class UserCapabilityListener {
+
+    private final LPForgePlugin plugin;
+
+    public UserCapabilityListener(LPForgePlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @SubscribeEvent
     public void onRegisterCapabilities(RegisterCapabilitiesEvent event) {
@@ -60,13 +67,17 @@ public class UserCapabilityListener {
         Player previousPlayer = event.getOriginal();
         Player currentPlayer = event.getEntity();
 
+        if (!(currentPlayer instanceof ServerPlayer)) {
+           return;
+        }
+
         previousPlayer.reviveCaps();
         try {
             UserCapabilityImpl previous = UserCapabilityImpl.get(previousPlayer);
             UserCapabilityImpl current = UserCapabilityImpl.get(currentPlayer);
 
-            current.initialise(previous);
-            current.getQueryOptionsCache().invalidate();
+            current.initialise(previous, ((ServerPlayer) currentPlayer), this.plugin);
+            current.getQueryOptionsSupplier().invalidateCache();
         } catch (IllegalStateException e) {
             // continue on if we cannot copy original data
         } finally {

--- a/forge/src/main/java/me/lucko/luckperms/forge/listeners/ForgeConnectionListener.java
+++ b/forge/src/main/java/me/lucko/luckperms/forge/listeners/ForgeConnectionListener.java
@@ -148,7 +148,7 @@ public class ForgeConnectionListener extends AbstractConnectionListener {
 
         // initialise capability
         UserCapabilityImpl userCapability = UserCapabilityImpl.get(player);
-        userCapability.initialise(user, player, this.plugin.getContextManager());
+        userCapability.initialise(user, player, this.plugin);
         this.plugin.getContextManager().signalContextUpdate(player);
     }
 

--- a/forge/src/main/java/me/lucko/luckperms/forge/service/ForgePermissionHandler.java
+++ b/forge/src/main/java/me/lucko/luckperms/forge/service/ForgePermissionHandler.java
@@ -82,7 +82,7 @@ public class ForgePermissionHandler implements IPermissionHandler {
 
         if (capability != null) {
             User user = capability.getUser();
-            QueryOptions queryOptions = capability.getQueryOptionsCache().getQueryOptions();
+            QueryOptions queryOptions = capability.getQueryOptionsSupplier().getQueryOptions();
 
             T value = getPermissionValue(user, queryOptions, node, context);
             if (value != null) {

--- a/neoforge/src/main/java/me/lucko/luckperms/neoforge/context/NeoForgeContextManager.java
+++ b/neoforge/src/main/java/me/lucko/luckperms/neoforge/context/NeoForgeContextManager.java
@@ -25,17 +25,15 @@
 
 package me.lucko.luckperms.neoforge.context;
 
-import me.lucko.luckperms.common.config.ConfigKeys;
-import me.lucko.luckperms.common.context.manager.InlineContextManager;
+import me.lucko.luckperms.common.context.manager.SimpleContextManager;
 import me.lucko.luckperms.neoforge.LPNeoForgePlugin;
-import net.luckperms.api.context.ImmutableContextSet;
 import net.luckperms.api.query.OptionKey;
 import net.luckperms.api.query.QueryOptions;
 import net.minecraft.server.level.ServerPlayer;
 
 import java.util.UUID;
 
-public class NeoForgeContextManager extends InlineContextManager<ServerPlayer, ServerPlayer> {
+public class NeoForgeContextManager extends SimpleContextManager<ServerPlayer, ServerPlayer> {
     public static final OptionKey<Boolean> INTEGRATED_SERVER_OWNER = OptionKey.of("integrated_server_owner", Boolean.class);
 
     public NeoForgeContextManager(LPNeoForgePlugin plugin) {
@@ -48,12 +46,9 @@ public class NeoForgeContextManager extends InlineContextManager<ServerPlayer, S
     }
 
     @Override
-    public QueryOptions formQueryOptions(ServerPlayer subject, ImmutableContextSet contextSet) {
-        QueryOptions.Builder builder = this.plugin.getConfiguration().get(ConfigKeys.GLOBAL_QUERY_OPTIONS).toBuilder();
+    public void customizeQueryOptions(ServerPlayer subject, QueryOptions.Builder builder) {
         if (subject.getServer() != null && subject.getServer().isSingleplayerOwner(subject.getGameProfile())) {
             builder.option(INTEGRATED_SERVER_OWNER, true);
         }
-
-        return builder.context(contextSet).build();
     }
 }

--- a/nukkit/src/main/java/me/lucko/luckperms/nukkit/context/NukkitContextManager.java
+++ b/nukkit/src/main/java/me/lucko/luckperms/nukkit/context/NukkitContextManager.java
@@ -26,44 +26,24 @@
 package me.lucko.luckperms.nukkit.context;
 
 import cn.nukkit.Player;
-import com.github.benmanes.caffeine.cache.LoadingCache;
-import me.lucko.luckperms.common.cache.LoadingMap;
-import me.lucko.luckperms.common.config.ConfigKeys;
-import me.lucko.luckperms.common.context.manager.ContextManager;
-import me.lucko.luckperms.common.context.manager.QueryOptionsCache;
-import me.lucko.luckperms.common.util.CaffeineFactory;
+import me.lucko.luckperms.common.context.manager.DetachedContextManager;
+import me.lucko.luckperms.common.context.manager.QueryOptionsSupplier;
 import me.lucko.luckperms.nukkit.LPNukkitPlugin;
-import net.luckperms.api.context.ImmutableContextSet;
+import me.lucko.luckperms.nukkit.inject.permissible.LuckPermsPermissible;
+import me.lucko.luckperms.nukkit.inject.permissible.PermissibleInjector;
 import net.luckperms.api.query.OptionKey;
 import net.luckperms.api.query.QueryOptions;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
-public class NukkitContextManager extends ContextManager<Player, Player> {
+public class NukkitContextManager extends DetachedContextManager<Player, Player> {
 
     public static final OptionKey<Boolean> OP_OPTION = OptionKey.of("op", Boolean.class);
 
-    // cache the creation of ContextsCache instances for online players with no expiry
-    private final LoadingMap<Player, QueryOptionsCache<Player>> onlineSubjectCaches = LoadingMap.of(key -> new QueryOptionsCache<>(key, this));
-
-    // cache the creation of ContextsCache instances for offline players with a 1m expiry
-    private final LoadingCache<Player, QueryOptionsCache<Player>> offlineSubjectCaches = CaffeineFactory.newBuilder()
-            .expireAfterAccess(1, TimeUnit.MINUTES)
-            .build(key -> {
-                QueryOptionsCache<Player> cache = this.onlineSubjectCaches.getIfPresent(key);
-                if (cache != null) {
-                    return cache;
-                }
-                return new QueryOptionsCache<>(key, this);
-            });
-
     public NukkitContextManager(LPNukkitPlugin plugin) {
         super(plugin, Player.class, Player.class);
-    }
-
-    public void onPlayerQuit(Player player) {
-        this.onlineSubjectCaches.remove(player);
     }
 
     @Override
@@ -72,38 +52,19 @@ public class NukkitContextManager extends ContextManager<Player, Player> {
     }
 
     @Override
-    public QueryOptionsCache<Player> getCacheFor(Player subject) {
-        if (subject == null) {
-            throw new NullPointerException("subject");
+    public @Nullable QueryOptionsSupplier getQueryOptionsSupplier(Player subject) {
+        Objects.requireNonNull(subject, "subject");
+        LuckPermsPermissible permissible = PermissibleInjector.get(subject);
+        if (permissible != null) {
+            return permissible.getQueryOptionsSupplier();
         }
-
-        if (subject.isOnline()) {
-            return this.onlineSubjectCaches.get(subject);
-        } else {
-            return this.offlineSubjectCaches.get(subject);
-        }
+        return null;
     }
 
     @Override
-    protected void invalidateCache(Player subject) {
-        QueryOptionsCache<Player> cache = this.onlineSubjectCaches.getIfPresent(subject);
-        if (cache != null) {
-            cache.invalidate();
-        }
-
-        cache = this.offlineSubjectCaches.getIfPresent(subject);
-        if (cache != null) {
-            cache.invalidate();
-        }
-    }
-
-    @Override
-    public QueryOptions formQueryOptions(Player subject, ImmutableContextSet contextSet) {
-        QueryOptions.Builder queryOptions = this.plugin.getConfiguration().get(ConfigKeys.GLOBAL_QUERY_OPTIONS).toBuilder();
+    public void customizeQueryOptions(Player subject, QueryOptions.Builder builder) {
         if (subject.isOp()) {
-            queryOptions.option(OP_OPTION, true);
+            builder.option(OP_OPTION, true);
         }
-
-        return queryOptions.context(contextSet).build();
     }
 }

--- a/nukkit/src/main/java/me/lucko/luckperms/nukkit/inject/permissible/LuckPermsPermissible.java
+++ b/nukkit/src/main/java/me/lucko/luckperms/nukkit/inject/permissible/LuckPermsPermissible.java
@@ -35,7 +35,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import me.lucko.luckperms.common.cacheddata.result.TristateResult;
 import me.lucko.luckperms.common.config.ConfigKeys;
-import me.lucko.luckperms.common.context.manager.QueryOptionsCache;
+import me.lucko.luckperms.common.context.manager.QueryOptionsSupplier;
 import me.lucko.luckperms.common.model.User;
 import me.lucko.luckperms.common.verbose.event.CheckOrigin;
 import me.lucko.luckperms.nukkit.LPNukkitPlugin;
@@ -93,7 +93,7 @@ public class LuckPermsPermissible extends PermissibleBase {
     private final LPNukkitPlugin plugin;
 
     // caches context lookups for the player
-    private final QueryOptionsCache<Player> queryOptionsSupplier;
+    private final QueryOptionsSupplier queryOptionsSupplier;
 
     // the players previous permissible. (the one they had before this one was injected)
     private PermissibleBase oldPermissible = null;
@@ -110,7 +110,7 @@ public class LuckPermsPermissible extends PermissibleBase {
         this.user = Objects.requireNonNull(user, "user");
         this.player = Objects.requireNonNull(player, "player");
         this.plugin = Objects.requireNonNull(plugin, "plugin");
-        this.queryOptionsSupplier = plugin.getContextManager().getCacheFor(player);
+        this.queryOptionsSupplier = plugin.getContextManager().createQueryOptionsSupplier(player);
 
         injectFakeAttachmentsList();
     }
@@ -276,7 +276,7 @@ public class LuckPermsPermissible extends PermissibleBase {
         // the query options cache when op status changes.
         // (#invalidate is a fast call)
         if (this.queryOptionsSupplier != null) { // this method is called by the super class constructor, before this class has fully initialised
-            this.queryOptionsSupplier.invalidate();
+            this.queryOptionsSupplier.invalidateCache();
         }
 
         // but we don't need to do anything else in this method, unlike the Nukkit impl.
@@ -297,6 +297,10 @@ public class LuckPermsPermissible extends PermissibleBase {
 
     public LPNukkitPlugin getPlugin() {
         return this.plugin;
+    }
+
+    public QueryOptionsSupplier getQueryOptionsSupplier() {
+        return this.queryOptionsSupplier;
     }
 
     PermissibleBase getOldPermissible() {

--- a/nukkit/src/main/java/me/lucko/luckperms/nukkit/inject/permissible/PermissibleInjector.java
+++ b/nukkit/src/main/java/me/lucko/luckperms/nukkit/inject/permissible/PermissibleInjector.java
@@ -28,6 +28,7 @@ package me.lucko.luckperms.nukkit.inject.permissible;
 import cn.nukkit.Player;
 import cn.nukkit.permission.PermissibleBase;
 import cn.nukkit.permission.PermissionAttachment;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.lang.reflect.Field;
 import java.util.Set;
@@ -139,6 +140,19 @@ public final class PermissibleInjector {
                 PLAYER_PERMISSIBLE_FIELD.set(player, newPb);
             }
         }
+    }
+
+    public static @Nullable LuckPermsPermissible get(Player player) {
+        PermissibleBase permissibleBase;
+        try {
+            permissibleBase = (PermissibleBase) PLAYER_PERMISSIBLE_FIELD.get(player);
+        } catch (IllegalAccessException e) {
+            return null;
+        }
+        if (permissibleBase instanceof LuckPermsPermissible) {
+            return (LuckPermsPermissible) permissibleBase;
+        }
+        return null;
     }
 
 }

--- a/nukkit/src/main/java/me/lucko/luckperms/nukkit/listeners/NukkitConnectionListener.java
+++ b/nukkit/src/main/java/me/lucko/luckperms/nukkit/listeners/NukkitConnectionListener.java
@@ -215,9 +215,6 @@ public class NukkitConnectionListener extends AbstractConnectionListener impleme
             if (this.plugin.getConfiguration().get(ConfigKeys.AUTO_OP)) {
                 player.setOp(false);
             }
-
-            // remove their contexts cache
-            this.plugin.getContextManager().onPlayerQuit(player);
         }, 1, true);
     }
 

--- a/sponge/src/main/java/me/lucko/luckperms/sponge/context/SpongeContextManager.java
+++ b/sponge/src/main/java/me/lucko/luckperms/sponge/context/SpongeContextManager.java
@@ -25,20 +25,23 @@
 
 package me.lucko.luckperms.sponge.context;
 
-import me.lucko.luckperms.common.context.manager.InlineContextManager;
+import me.lucko.luckperms.common.config.ConfigKeys;
+import me.lucko.luckperms.common.context.manager.SimpleContextManager;
 import me.lucko.luckperms.sponge.LPSpongePlugin;
 import me.lucko.luckperms.sponge.service.model.ContextCalculatorProxy;
 import me.lucko.luckperms.sponge.service.model.TemporaryCauseHolderSubject;
 import net.luckperms.api.context.ContextCalculator;
 import net.luckperms.api.context.ContextConsumer;
+import net.luckperms.api.context.ContextSet;
 import net.luckperms.api.context.StaticContextCalculator;
+import net.luckperms.api.query.QueryOptions;
 import org.spongepowered.api.entity.living.player.server.ServerPlayer;
 import org.spongepowered.api.event.Cause;
 import org.spongepowered.api.service.permission.Subject;
 
 import java.util.UUID;
 
-public class SpongeContextManager extends InlineContextManager<Subject, ServerPlayer> {
+public class SpongeContextManager extends SimpleContextManager<Subject, ServerPlayer> {
 
     public SpongeContextManager(LPSpongePlugin plugin) {
         super(plugin, Subject.class, ServerPlayer.class);
@@ -75,4 +78,11 @@ public class SpongeContextManager extends InlineContextManager<Subject, ServerPl
     public UUID getUniqueId(ServerPlayer player) {
         return player.uniqueId();
     }
+
+    public QueryOptions formQueryOptions(ContextSet contexts) {
+        QueryOptions.Builder builder = this.plugin.getConfiguration().get(ConfigKeys.GLOBAL_QUERY_OPTIONS).toBuilder().context(contexts);
+        customizeStaticQueryOptions(builder);
+        return builder.build();
+    }
+
 }

--- a/standalone/src/main/java/me/lucko/luckperms/standalone/stub/StandaloneContextManager.java
+++ b/standalone/src/main/java/me/lucko/luckperms/standalone/stub/StandaloneContextManager.java
@@ -25,20 +25,13 @@
 
 package me.lucko.luckperms.standalone.stub;
 
-import me.lucko.luckperms.common.config.ConfigKeys;
-import me.lucko.luckperms.common.context.manager.ContextManager;
-import me.lucko.luckperms.common.context.manager.QueryOptionsCache;
+import me.lucko.luckperms.common.context.manager.SimpleContextManager;
 import me.lucko.luckperms.standalone.LPStandalonePlugin;
 import me.lucko.luckperms.standalone.app.integration.StandaloneSender;
-import me.lucko.luckperms.standalone.app.integration.StandaloneUser;
-import net.luckperms.api.context.ImmutableContextSet;
-import net.luckperms.api.query.QueryOptions;
 
 import java.util.UUID;
 
-public class StandaloneContextManager extends ContextManager<StandaloneSender, StandaloneSender> {
-    private final QueryOptionsCache<StandaloneSender> singletonCache = new QueryOptionsCache<>(StandaloneUser.INSTANCE, this);
-
+public class StandaloneContextManager extends SimpleContextManager<StandaloneSender, StandaloneSender> {
     public StandaloneContextManager(LPStandalonePlugin plugin) {
         super(plugin, StandaloneSender.class, StandaloneSender.class);
     }
@@ -46,29 +39,5 @@ public class StandaloneContextManager extends ContextManager<StandaloneSender, S
     @Override
     public UUID getUniqueId(StandaloneSender player) {
         return player.getUniqueId();
-    }
-
-    @Override
-    public QueryOptionsCache<StandaloneSender> getCacheFor(StandaloneSender subject) {
-        if (subject == null) {
-            throw new NullPointerException("subject");
-        }
-        if (subject == StandaloneUser.INSTANCE) {
-            return this.singletonCache;
-        }
-
-        // just return a new one every time - not optimal but this case should only be hit using unit tests anyway
-        return new QueryOptionsCache<>(subject, this);
-    }
-
-    @Override
-    protected void invalidateCache(StandaloneSender subject) {
-        this.singletonCache.invalidate();
-    }
-
-    @Override
-    public QueryOptions formQueryOptions(StandaloneSender subject, ImmutableContextSet contextSet) {
-        QueryOptions.Builder queryOptions = this.plugin.getConfiguration().get(ConfigKeys.GLOBAL_QUERY_OPTIONS).toBuilder();
-        return queryOptions.context(contextSet).build();
     }
 }

--- a/velocity/src/main/java/me/lucko/luckperms/velocity/context/VelocityContextManager.java
+++ b/velocity/src/main/java/me/lucko/luckperms/velocity/context/VelocityContextManager.java
@@ -26,12 +26,12 @@
 package me.lucko.luckperms.velocity.context;
 
 import com.velocitypowered.api.proxy.Player;
-import me.lucko.luckperms.common.context.manager.InlineContextManager;
+import me.lucko.luckperms.common.context.manager.SimpleContextManager;
 import me.lucko.luckperms.velocity.LPVelocityPlugin;
 
 import java.util.UUID;
 
-public class VelocityContextManager extends InlineContextManager<Player, Player> {
+public class VelocityContextManager extends SimpleContextManager<Player, Player> {
     public VelocityContextManager(LPVelocityPlugin plugin) {
         super(plugin, Player.class, Player.class);
     }

--- a/velocity/src/main/java/me/lucko/luckperms/velocity/listeners/VelocityConnectionListener.java
+++ b/velocity/src/main/java/me/lucko/luckperms/velocity/listeners/VelocityConnectionListener.java
@@ -38,6 +38,7 @@ import me.lucko.luckperms.common.locale.TranslationManager;
 import me.lucko.luckperms.common.model.User;
 import me.lucko.luckperms.common.plugin.util.AbstractConnectionListener;
 import me.lucko.luckperms.velocity.LPVelocityPlugin;
+import me.lucko.luckperms.velocity.context.VelocityContextManager;
 import me.lucko.luckperms.velocity.service.PlayerPermissionProvider;
 import me.lucko.luckperms.velocity.util.AdventureCompat;
 
@@ -90,7 +91,8 @@ public class VelocityConnectionListener extends AbstractConnectionListener {
             try {
                 User user = loadUser(p.getUniqueId(), p.getUsername());
                 recordConnection(p.getUniqueId());
-                e.setProvider(new PlayerPermissionProvider(p, user, this.plugin.getContextManager().getCacheFor(p)));
+                VelocityContextManager contextManager = this.plugin.getContextManager();
+                e.setProvider(new PlayerPermissionProvider(p, user, contextManager::getQueryOptions));
                 this.plugin.getEventDispatcher().dispatchPlayerLoginProcess(p.getUniqueId(), p.getUsername(), user);
             } catch (Exception ex) {
                 this.plugin.getLogger().severe("Exception occurred whilst loading data for " + p.getUniqueId() + " - " + p.getUsername(), ex);

--- a/velocity/src/main/java/me/lucko/luckperms/velocity/service/PlayerPermissionProvider.java
+++ b/velocity/src/main/java/me/lucko/luckperms/velocity/service/PlayerPermissionProvider.java
@@ -25,23 +25,24 @@
 
 package me.lucko.luckperms.velocity.service;
 
+import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.velocitypowered.api.permission.PermissionFunction;
 import com.velocitypowered.api.permission.PermissionProvider;
 import com.velocitypowered.api.permission.PermissionSubject;
 import com.velocitypowered.api.permission.Tristate;
 import com.velocitypowered.api.proxy.Player;
-import me.lucko.luckperms.common.context.manager.QueryOptionsSupplier;
 import me.lucko.luckperms.common.model.User;
 import me.lucko.luckperms.common.verbose.event.CheckOrigin;
+import net.luckperms.api.query.QueryOptions;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class PlayerPermissionProvider implements PermissionProvider, PermissionFunction {
     private final Player player;
     private final User user;
-    private final QueryOptionsSupplier queryOptionsSupplier;
+    private final Function<Player, QueryOptions> queryOptionsSupplier;
 
-    public PlayerPermissionProvider(Player player, User user, QueryOptionsSupplier queryOptionsSupplier) {
+    public PlayerPermissionProvider(Player player, User user, Function<Player, QueryOptions> queryOptionsSupplier) {
         this.player = player;
         this.user = user;
         this.queryOptionsSupplier = queryOptionsSupplier;
@@ -55,6 +56,7 @@ public class PlayerPermissionProvider implements PermissionProvider, PermissionF
 
     @Override
     public @NonNull Tristate getPermissionValue(@NonNull String permission) {
-        return CompatibilityUtil.convertTristate(this.user.getCachedData().getPermissionData(this.queryOptionsSupplier.getQueryOptions()).checkPermission(permission, CheckOrigin.PLATFORM_API_HAS_PERMISSION).result());
+        QueryOptions queryOptions = this.queryOptionsSupplier.apply(this.player);
+        return CompatibilityUtil.convertTristate(this.user.getCachedData().getPermissionData(queryOptions).checkPermission(permission, CheckOrigin.PLATFORM_API_HAS_PERMISSION).result());
     }
 }


### PR DESCRIPTION
Maybe a fix for #4049

In the past for some platforms, LuckPerms used a global map as a fallback for locating `QueryOptionsCache` instances - this has proven to be a bit brittle and potentially the cause of some memory leaks, although never confirmed.

I can't see anything specifically wrong in the old code, but using `Player` as the key in a map feels wrong and I have a feeling it is the cause of the issues observed in #4049.