### PR TITLE
Fixes LuckPerms is not available on NeoForge Modloader by incorrect config class

### DIFF
--- a/neoforge/gradle.properties
+++ b/neoforge/gradle.properties
@@ -1,2 +1,2 @@
 minecraftVersion=1.21.5
-neoForgeVersion=21.5.2-beta
+neoForgeVersion=21.5.63-beta

--- a/neoforge/src/main/java/me/lucko/luckperms/neoforge/service/NeoForgePermissionHandlerListener.java
+++ b/neoforge/src/main/java/me/lucko/luckperms/neoforge/service/NeoForgePermissionHandlerListener.java
@@ -29,7 +29,7 @@ import me.lucko.luckperms.common.command.access.CommandPermission;
 import me.lucko.luckperms.neoforge.LPNeoForgePlugin;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.common.ModConfigSpec;
-import net.neoforged.neoforge.common.NeoForgeConfig;
+import net.neoforged.neoforge.common.config.NeoForgeServerConfig;
 import net.neoforged.neoforge.server.permission.events.PermissionGatherEvent;
 import net.neoforged.neoforge.server.permission.handler.DefaultPermissionHandler;
 import net.neoforged.neoforge.server.permission.nodes.PermissionNode;
@@ -45,7 +45,7 @@ public class NeoForgePermissionHandlerListener {
     @SubscribeEvent
     public void onPermissionGatherHandler(PermissionGatherEvent.Handler event) {
         // Override the default permission handler with LuckPerms
-        ModConfigSpec.ConfigValue<String> permissionHandler = NeoForgeConfig.SERVER.permissionHandler;
+        ModConfigSpec.ConfigValue<String> permissionHandler = NeoForgeServerConfig.INSTANCE.permissionHandler;
         if (permissionHandler.get().equals(DefaultPermissionHandler.IDENTIFIER.toString())) {
             permissionHandler.set(NeoForgePermissionHandler.IDENTIFIER.toString());
         }


### PR DESCRIPTION
# Why does that happen
* Closes https://github.com/LuckPerms/LuckPerms/issues/4070

Simply, NeoForge config class does not work as how Forge config works. I fixed a few codes, and now it correctly follows the existing class from NeoForge.

Also, a minor nitpick updating NeoForge version.

For those who need this, you can find the release of my fix here: https://github.com/EvilDragonfiend/LuckPerms/releases/tag/TemporaryBuild

## Testing evidence

![image](https://github.com/user-attachments/assets/b2865244-c21d-4261-8ee2-1c0f9db413eb)

![image](https://github.com/user-attachments/assets/00e64592-a1e2-4dcf-9795-8d683bffe218)

![image](https://github.com/user-attachments/assets/4a0d07b8-28fd-43db-9efa-f40ef31548ec)
