### PR TITLE
Update log4j version in standalone build

### DIFF
--- a/standalone/app/build.gradle
+++ b/standalone/app/build.gradle
@@ -9,8 +9,8 @@ targetCompatibility = 17
 dependencies {
     implementation project(':api')
 
-    api 'org.apache.logging.log4j:log4j-core:2.17.2'
-    api 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.2'
+    api 'org.apache.logging.log4j:log4j-core:2.24.3'
+    api 'org.apache.logging.log4j:log4j-slf4j-impl:2.24.3'
     api 'net.minecrell:terminalconsoleappender:1.3.0'
     api 'org.jline:jline-terminal-jansi:3.20.0'
 


### PR DESCRIPTION
Updated Log4j dependency to a version compatible with the Spring ecosystem. This prevents classpath conflicts and logging initialization issues when running LuckPerms as a library inside a Spring-based environment.