### PR TITLE
fix(fabric): prevent async task execution when stopping server

### DIFF
--- a/fabric/src/main/java/me/lucko/luckperms/fabric/listeners/FabricConnectionListener.java
+++ b/fabric/src/main/java/me/lucko/luckperms/fabric/listeners/FabricConnectionListener.java
@@ -131,7 +131,9 @@ public class FabricConnectionListener extends AbstractConnectionListener {
     }
 
     private void onDisconnect(ServerPlayNetworkHandler netHandler, MinecraftServer server) {
-        handleDisconnect(netHandler.player.getUuid());
+        if (!server.isStopped()) {
+            handleDisconnect(netHandler.player.getUuid());
+        }
     }
 
 }


### PR DESCRIPTION
Tested and Fixed #3857.

The issue was caused by calling `this.plugin.getBootstrap().getScheduler().executeAsync` inside `handleDisconnect` when the server is shutting down. At this point, the scheduler is no longer available on Fabric, which leads to a `RejectedExecutionException`. Specifically, `MinecraftServer` throws `RejectedExecutionException("Server already shutting down")` when this code is executed.

This does not occur on other platforms (like Bukkit) because listeners are automatically unregistered during `onDisable`. However, Fabric has no `disable` concept and only provides `onInitializeServer` with `SERVER_STARTING` / `SERVER_STOPPING` events.