### PR TITLE
Add Redis Sentinel support for messaging

### DIFF
--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -268,6 +268,14 @@ redis:
   address: localhost
   username: ''
   password: ''
+  # Settings for Redis Sentinel.
+  # Sentinel provides high availability for Redis by monitoring master/replica instances.
+  # Port 26379 is used by default for sentinel nodes.
+  sentinel:
+    enabled: false
+    master: mymaster
+    addresses:
+      - localhost:26379
 
 # Settings for Nats.
 # Port 4222 is used by default; set address to "host:port" if differs

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -276,6 +276,8 @@ redis:
     master: mymaster
     addresses:
       - localhost:26379
+    username: ''
+    password: ''
 
 # Settings for Nats.
 # Port 4222 is used by default; set address to "host:port" if differs

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -274,6 +274,8 @@ redis:
     master: mymaster
     addresses:
       - localhost:26379
+    username: ''
+    password: ''
 
 # Settings for Nats.
 # Port 4222 is used by default; set address to "host:port" if differs

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -266,6 +266,14 @@ redis:
   address: localhost
   username: ''
   password: ''
+  # Settings for Redis Sentinel.
+  # Sentinel provides high availability for Redis by monitoring master/replica instances.
+  # Port 26379 is used by default for sentinel nodes.
+  sentinel:
+    enabled: false
+    master: mymaster
+    addresses:
+      - localhost:26379
 
 # Settings for Nats.
 # Port 4222 is used by default; set address to "host:port" if differs

--- a/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
@@ -721,6 +721,16 @@ public final class ConfigKeys {
     public static final ConfigKey<List<String>> REDIS_SENTINEL_ADDRESSES = notReloadable(stringListKey("redis.sentinel.addresses", ImmutableList.of()));
 
     /**
+     * The username to connect to the redis sentinel nodes with, or an empty string if it should use default
+     */
+    public static final ConfigKey<String> REDIS_SENTINEL_USERNAME = notReloadable(stringKey("redis.sentinel.username", ""));
+
+    /**
+     * The password in use by the redis sentinel nodes, or an empty string if there is no password
+     */
+    public static final ConfigKey<String> REDIS_SENTINEL_PASSWORD = notReloadable(stringKey("redis.sentinel.password", ""));
+
+    /**
      * If nats messaging is enabled
      */
     public static final ConfigKey<Boolean> NATS_ENABLED = notReloadable(booleanKey("nats.enabled", false));

--- a/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
@@ -706,6 +706,21 @@ public final class ConfigKeys {
     public static final ConfigKey<Boolean> REDIS_SSL = notReloadable(booleanKey("redis.ssl", false));
 
     /**
+     * If redis sentinel is enabled
+     */
+    public static final ConfigKey<Boolean> REDIS_SENTINEL_ENABLED = notReloadable(booleanKey("redis.sentinel.enabled", false));
+
+    /**
+     * The name of the redis sentinel master
+     */
+    public static final ConfigKey<String> REDIS_SENTINEL_MASTER = notReloadable(stringKey("redis.sentinel.master", "mymaster"));
+
+    /**
+     * The addresses of the redis sentinel nodes
+     */
+    public static final ConfigKey<List<String>> REDIS_SENTINEL_ADDRESSES = notReloadable(stringListKey("redis.sentinel.addresses", ImmutableList.of()));
+
+    /**
      * If nats messaging is enabled
      */
     public static final ConfigKey<Boolean> NATS_ENABLED = notReloadable(booleanKey("nats.enabled", false));

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
@@ -211,7 +211,13 @@ public class MessagingFactory<P extends LuckPermsPlugin> {
             }
             boolean ssl = config.get(ConfigKeys.REDIS_SSL);
 
-            if (!addresses.isEmpty()) {
+            boolean sentinelEnabled = config.get(ConfigKeys.REDIS_SENTINEL_ENABLED);
+            if (sentinelEnabled) {
+                // redis sentinel
+                String masterName = config.get(ConfigKeys.REDIS_SENTINEL_MASTER);
+                List<String> sentinelAddresses = config.get(ConfigKeys.REDIS_SENTINEL_ADDRESSES);
+                redis.init(masterName, sentinelAddresses, username, password, ssl);
+            } else if (!addresses.isEmpty()) {
                 // redis cluster
                 addresses = new ArrayList<>(addresses);
                 if (address != null) {

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
@@ -216,7 +216,15 @@ public class MessagingFactory<P extends LuckPermsPlugin> {
                 // redis sentinel
                 String masterName = config.get(ConfigKeys.REDIS_SENTINEL_MASTER);
                 List<String> sentinelAddresses = config.get(ConfigKeys.REDIS_SENTINEL_ADDRESSES);
-                redis.init(masterName, sentinelAddresses, username, password, ssl);
+                String sentinelUsername = config.get(ConfigKeys.REDIS_SENTINEL_USERNAME);
+                String sentinelPassword = config.get(ConfigKeys.REDIS_SENTINEL_PASSWORD);
+                if (sentinelUsername.isEmpty()) {
+                    sentinelUsername = null;
+                }
+                if (sentinelPassword.isEmpty()) {
+                    sentinelPassword = null;
+                }
+                redis.init(masterName, sentinelAddresses, username, password, ssl, sentinelUsername, sentinelPassword);
             } else if (!addresses.isEmpty()) {
                 // redis cluster
                 addresses = new ArrayList<>(addresses);

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/redis/RedisMessenger.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/redis/RedisMessenger.java
@@ -36,6 +36,7 @@ import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPooled;
 import redis.clients.jedis.JedisPubSub;
+import redis.clients.jedis.JedisSentineled;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.UnifiedJedis;
 
@@ -48,6 +49,7 @@ import java.util.stream.Collectors;
  */
 public class RedisMessenger implements Messenger {
     private static final String CHANNEL = "luckperms:update";
+    private static final int SENTINEL_DEFAULT_PORT = 26379;
 
     private final LuckPermsPlugin plugin;
     private final IncomingMessageConsumer consumer;
@@ -70,6 +72,13 @@ public class RedisMessenger implements Messenger {
         this.init(new JedisPooled(parseAddress(address), jedisConfig(username, password, ssl)));
     }
 
+    public void init(String masterName, List<String> sentinelAddresses, String username, String password, boolean ssl) {
+        Set<HostAndPort> sentinels = sentinelAddresses.stream()
+                .map(addr -> parseAddress(addr, SENTINEL_DEFAULT_PORT))
+                .collect(Collectors.toSet());
+        this.init(new JedisSentineled(masterName, jedisConfig(username, password, ssl), sentinels, jedisConfig(null, null, ssl)));
+    }
+
     private void init(UnifiedJedis jedis) {
         this.jedis = jedis;
         this.sub = new Subscription(this);
@@ -86,9 +95,13 @@ public class RedisMessenger implements Messenger {
     }
 
     private static HostAndPort parseAddress(String address) {
+        return parseAddress(address, Protocol.DEFAULT_PORT);
+    }
+
+    private static HostAndPort parseAddress(String address, int defaultPort) {
         me.lucko.luckperms.common.util.HostAndPort hostAndPort = new me.lucko.luckperms.common.util.HostAndPort(address)
                 .requireBracketsForIPv6()
-                .withDefaultPort(Protocol.DEFAULT_PORT);
+                .withDefaultPort(defaultPort);
         String host = hostAndPort.getHost();
         int port = hostAndPort.getPort();
         return new HostAndPort(host, port);
@@ -162,6 +175,8 @@ public class RedisMessenger implements Messenger {
                 return !((JedisPooled) jedis).getPool().isClosed();
             } else if (jedis instanceof JedisCluster) {
                 return !((JedisCluster) jedis).getClusterNodes().isEmpty();
+            } else if (jedis instanceof JedisSentineled) {
+                return true;
             } else {
                 throw new RuntimeException("Unknown jedis type: " + jedis.getClass().getName());
             }

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/redis/RedisMessenger.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/redis/RedisMessenger.java
@@ -72,11 +72,11 @@ public class RedisMessenger implements Messenger {
         this.init(new JedisPooled(parseAddress(address), jedisConfig(username, password, ssl)));
     }
 
-    public void init(String masterName, List<String> sentinelAddresses, String username, String password, boolean ssl) {
+    public void init(String masterName, List<String> sentinelAddresses, String username, String password, boolean ssl, String sentinelUsername, String sentinelPassword) {
         Set<HostAndPort> sentinels = sentinelAddresses.stream()
                 .map(addr -> parseAddress(addr, SENTINEL_DEFAULT_PORT))
                 .collect(Collectors.toSet());
-        this.init(new JedisSentineled(masterName, jedisConfig(username, password, ssl), sentinels, jedisConfig(null, null, ssl)));
+        this.init(new JedisSentineled(masterName, jedisConfig(username, password, ssl), sentinels, jedisConfig(sentinelUsername, sentinelPassword, ssl)));
     }
 
     private void init(UnifiedJedis jedis) {

--- a/fabric/src/main/resources/luckperms.conf
+++ b/fabric/src/main/resources/luckperms.conf
@@ -271,6 +271,14 @@ redis {
   address = "localhost"
   username = ""
   password = ""
+  # Settings for Redis Sentinel.
+  # Sentinel provides high availability for Redis by monitoring master/replica instances.
+  # Port 26379 is used by default for sentinel nodes.
+  sentinel {
+    enabled = false
+    master = "mymaster"
+    addresses = ["localhost:26379"]
+  }
 }
 
 # Settings for nats.

--- a/fabric/src/main/resources/luckperms.conf
+++ b/fabric/src/main/resources/luckperms.conf
@@ -278,6 +278,8 @@ redis {
     enabled = false
     master = "mymaster"
     addresses = ["localhost:26379"]
+    username = ""
+    password = ""
   }
 }
 

--- a/forge/src/main/resources/luckperms.conf
+++ b/forge/src/main/resources/luckperms.conf
@@ -276,6 +276,8 @@ redis {
     enabled = false
     master = "mymaster"
     addresses = ["localhost:26379"]
+    username = ""
+    password = ""
   }
 }
 

--- a/forge/src/main/resources/luckperms.conf
+++ b/forge/src/main/resources/luckperms.conf
@@ -269,6 +269,14 @@ redis {
   address = "localhost"
   username = ""
   password = ""
+  # Settings for Redis Sentinel.
+  # Sentinel provides high availability for Redis by monitoring master/replica instances.
+  # Port 26379 is used by default for sentinel nodes.
+  sentinel {
+    enabled = false
+    master = "mymaster"
+    addresses = ["localhost:26379"]
+  }
 }
 
 # Settings for nats.

--- a/neoforge/src/main/resources/luckperms.conf
+++ b/neoforge/src/main/resources/luckperms.conf
@@ -276,6 +276,8 @@ redis {
     enabled = false
     master = "mymaster"
     addresses = ["localhost:26379"]
+    username = ""
+    password = ""
   }
 }
 

--- a/neoforge/src/main/resources/luckperms.conf
+++ b/neoforge/src/main/resources/luckperms.conf
@@ -269,6 +269,14 @@ redis {
   address = "localhost"
   username = ""
   password = ""
+  # Settings for Redis Sentinel.
+  # Sentinel provides high availability for Redis by monitoring master/replica instances.
+  # Port 26379 is used by default for sentinel nodes.
+  sentinel {
+    enabled = false
+    master = "mymaster"
+    addresses = ["localhost:26379"]
+  }
 }
 
 # Settings for nats.

--- a/nukkit/src/main/resources/config.yml
+++ b/nukkit/src/main/resources/config.yml
@@ -263,6 +263,14 @@ redis:
   address: localhost
   username: ''
   password: ''
+  # Settings for Redis Sentinel.
+  # Sentinel provides high availability for Redis by monitoring master/replica instances.
+  # Port 26379 is used by default for sentinel nodes.
+  sentinel:
+    enabled: false
+    master: mymaster
+    addresses:
+      - localhost:26379
 
 # Settings for Nats.
 # Port 4222 is used by default; set address to "host:port" if differs

--- a/nukkit/src/main/resources/config.yml
+++ b/nukkit/src/main/resources/config.yml
@@ -271,6 +271,8 @@ redis:
     master: mymaster
     addresses:
       - localhost:26379
+    username: ''
+    password: ''
 
 # Settings for Nats.
 # Port 4222 is used by default; set address to "host:port" if differs

--- a/sponge/src/main/resources/luckperms.conf
+++ b/sponge/src/main/resources/luckperms.conf
@@ -271,6 +271,14 @@ redis {
   address = "localhost"
   username = ""
   password = ""
+  # Settings for Redis Sentinel.
+  # Sentinel provides high availability for Redis by monitoring master/replica instances.
+  # Port 26379 is used by default for sentinel nodes.
+  sentinel {
+    enabled = false
+    master = "mymaster"
+    addresses = ["localhost:26379"]
+  }
 }
 
 # Settings for nats.

--- a/sponge/src/main/resources/luckperms.conf
+++ b/sponge/src/main/resources/luckperms.conf
@@ -278,6 +278,8 @@ redis {
     enabled = false
     master = "mymaster"
     addresses = ["localhost:26379"]
+    username = ""
+    password = ""
   }
 }
 

--- a/standalone/src/main/resources/config.yml
+++ b/standalone/src/main/resources/config.yml
@@ -253,6 +253,14 @@ redis:
   address: localhost
   username: ''
   password: ''
+  # Settings for Redis Sentinel.
+  # Sentinel provides high availability for Redis by monitoring master/replica instances.
+  # Port 26379 is used by default for sentinel nodes.
+  sentinel:
+    enabled: false
+    master: mymaster
+    addresses:
+      - localhost:26379
 
 # Settings for Nats.
 # Port 4222 is used by default; set address to "host:port" if differs

--- a/standalone/src/main/resources/config.yml
+++ b/standalone/src/main/resources/config.yml
@@ -261,6 +261,8 @@ redis:
     master: mymaster
     addresses:
       - localhost:26379
+    username: ''
+    password: ''
 
 # Settings for Nats.
 # Port 4222 is used by default; set address to "host:port" if differs

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -265,6 +265,8 @@ redis:
     master: mymaster
     addresses:
       - localhost:26379
+    username: ''
+    password: ''
 
 # Settings for Nats.
 # Port 4222 is used by default; set address to "host:port" if differs

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -257,6 +257,14 @@ redis:
   address: localhost
   username: ''
   password: ''
+  # Settings for Redis Sentinel.
+  # Sentinel provides high availability for Redis by monitoring master/replica instances.
+  # Port 26379 is used by default for sentinel nodes.
+  sentinel:
+    enabled: false
+    master: mymaster
+    addresses:
+      - localhost:26379
 
 # Settings for Nats.
 # Port 4222 is used by default; set address to "host:port" if differs


### PR DESCRIPTION
Adds native Redis Sentinel support to the messaging system. Redis Sentinel provides high availability by monitoring master/replica instances and performing automatic failover when the master goes down - clients always get routed to the current master.

New `redis.sentinel` config section across all platforms with `enabled`, `master`, `addresses`, `username` and `password`. Sentinel credentials are separate from the main Redis credentials.

On the code side: five new config keys, a new `JedisSentineled` init path in `RedisMessenger` (with `parseAddress` extended for the sentinel default port 26379), sentinel-first check in `MessagingFactory`, and `isRedisAlive()` handling for the new type. Existing standalone and cluster setups are unaffected.