### PR TITLE
Support SpongeAPI15+

### DIFF
--- a/sponge/build.gradle
+++ b/sponge/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation project(':sponge:sponge-service-proxy')
     compileOnly project(':common:loader-utils')
 
-    compileOnly('org.spongepowered:spongeapi:12.0.0') {
+    compileOnly('org.spongepowered:spongeapi:15.0.0-SNAPSHOT') {
         exclude(module: 'configurate-core')
         exclude(module: 'configurate-hocon')
         exclude(module: 'configurate-gson')

--- a/sponge/loader/build.gradle
+++ b/sponge/loader/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'org.spongepowered:spongeapi:12.0.0'
+    compileOnly 'org.spongepowered:spongeapi:15.0.0-SNAPSHOT'
 
     implementation project(':api')
     implementation project(':common:loader-utils')

--- a/sponge/sponge-service-proxy/build.gradle
+++ b/sponge/sponge-service-proxy/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation project(':common')
     implementation project(':sponge:sponge-service')
 
-    compileOnly('org.spongepowered:spongeapi:12.0.0') {
+    compileOnly('org.spongepowered:spongeapi:15.0.0-SNAPSHOT') {
         exclude(module: 'configurate-core')
         exclude(module: 'configurate-hocon')
         exclude(module: 'configurate-gson')

--- a/sponge/sponge-service/build.gradle
+++ b/sponge/sponge-service/build.gradle
@@ -9,7 +9,7 @@ tasks.withType(JavaCompile).configureEach {
 dependencies {
     implementation project(':common')
 
-    compileOnly('org.spongepowered:spongeapi:12.0.0') {
+    compileOnly('org.spongepowered:spongeapi:15.0.0-SNAPSHOT') {
         exclude(module: 'configurate-core')
         exclude(module: 'configurate-hocon')
         exclude(module: 'configurate-gson')

--- a/sponge/src/main/java/me/lucko/luckperms/sponge/LPSpongeBootstrap.java
+++ b/sponge/src/main/java/me/lucko/luckperms/sponge/LPSpongeBootstrap.java
@@ -199,16 +199,7 @@ public class LPSpongeBootstrap implements LuckPermsBootstrap, LoaderBootstrap, B
     }
 
     public void registerListeners(Object obj) {
-        // Check if we are running Sponge API 9+
-        try {
-            final Method method = org.spongepowered.api.event.EventManager.class.getDeclaredMethod("registerListeners", PluginContainer.class, Object.class, MethodHandles.Lookup.class);
-            method.invoke(this.game.eventManager(), this.pluginContainer, obj, MethodHandles.lookup());
-            return;
-        } catch (Throwable t) {
-            // ignore
-        }
-        // Fallback to Sponge API 8
-        this.game.eventManager().registerListeners(this.pluginContainer, obj);
+        this.game.eventManager().registerListeners(this.pluginContainer, obj, MethodHandles.lookup());
     }
 
     // provide information about the plugin

--- a/sponge/src/main/java/me/lucko/luckperms/sponge/LPSpongePlugin.java
+++ b/sponge/src/main/java/me/lucko/luckperms/sponge/LPSpongePlugin.java
@@ -59,6 +59,8 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.query.QueryOptions;
+
+import org.spongepowered.api.Server;
 import org.spongepowered.api.command.Command;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.lifecycle.ProvideServiceEvent;
@@ -208,12 +210,12 @@ public class LPSpongePlugin extends AbstractLuckPermsPlugin {
         }
 
         @Listener
-        public void onPermissionServiceProvide(ProvideServiceEvent.EngineScoped<PermissionService> event) {
+        public void onPermissionServiceProvide(ProvideServiceEvent.EngineScoped<PermissionService, Server> event) {
             event.suggest(this.service::sponge);
         }
 
         @Listener
-        public void onContextServiceProvide(ProvideServiceEvent.EngineScoped<ContextService> event) {
+        public void onContextServiceProvide(ProvideServiceEvent.EngineScoped<ContextService, Server> event) {
             event.suggest(this.service::sponge);
         }
     }


### PR DESCRIPTION
Now the plugin correctly registers its service on the Sponge server with API version 15 and higher. I personally tested on API 19 with game version 26.1.1. However, this will break compatibility with earlier versions due to API differences.
Fixed Issue https://github.com/LuckPerms/LuckPerms/issues/4256