### PR TITLE
Add Folia support for Bukkit module

### DIFF
--- a/bukkit/loader/src/main/resources/plugin.yml
+++ b/bukkit/loader/src/main/resources/plugin.yml
@@ -10,6 +10,7 @@ load: STARTUP
 # remapping when the plugin is loaded. Note that despite what this setting might otherwise imply,
 # LP is still compatible with pre-1.13 releases.
 api-version: 1.13
+folia-supported: true
 
 # Load LuckPerms before Vault. This means that all plugins that (soft-)depend
 # on Vault depend on LuckPerms too.

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/LPBukkitBootstrap.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/LPBukkitBootstrap.java
@@ -25,6 +25,8 @@
 
 package me.lucko.luckperms.bukkit;
 
+import me.lucko.luckperms.bukkit.util.FoliaSchedulerHelper;
+import me.lucko.luckperms.bukkit.util.FoliaUtil;
 import me.lucko.luckperms.bukkit.util.NullSafeConsoleCommandSender;
 import me.lucko.luckperms.common.loader.LoaderBootstrap;
 import me.lucko.luckperms.common.plugin.bootstrap.BootstrappedWithLoader;
@@ -175,7 +177,11 @@ public class LPBukkitBootstrap implements LuckPermsBootstrap, LoaderBootstrap, B
             this.plugin.enable();
 
             // schedule a task to update the 'serverStarting' flag
-            getServer().getScheduler().runTask(this.loader, () -> this.serverStarting = false);
+            if (FoliaUtil.isFolia()) {
+                FoliaSchedulerHelper.executeOnGlobalRegion(this.loader, () -> this.serverStarting = false);
+            } else {
+                getServer().getScheduler().runTask(this.loader, () -> this.serverStarting = false);
+            }
         } finally {
             this.enableLatch.countDown();
         }

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/LPBukkitPlugin.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/LPBukkitPlugin.java
@@ -25,6 +25,8 @@
 
 package me.lucko.luckperms.bukkit;
 
+import me.lucko.luckperms.bukkit.util.FoliaSchedulerHelper;
+import me.lucko.luckperms.bukkit.util.FoliaUtil;
 import me.lucko.luckperms.bukkit.brigadier.LuckPermsBrigadier;
 import me.lucko.luckperms.bukkit.calculator.BukkitCalculatorFactory;
 import me.lucko.luckperms.bukkit.context.BukkitContextManager;
@@ -206,7 +208,11 @@ public class LPBukkitPlugin extends AbstractLuckPermsPlugin {
 
             // schedule another injection after all plugins have loaded
             // the entire pluginmanager instance is replaced by some plugins :(
-            this.bootstrap.getServer().getScheduler().runTaskLaterAsynchronously(this.bootstrap.getLoader(), injector, 1);
+            if (FoliaUtil.isFolia()) {
+                FoliaSchedulerHelper.executeAsync(this.bootstrap.getLoader(), injector);
+            } else {
+                this.bootstrap.getServer().getScheduler().runTaskLaterAsynchronously(this.bootstrap.getLoader(), injector, 1);
+            }
         }
 
         /*
@@ -268,11 +274,16 @@ public class LPBukkitPlugin extends AbstractLuckPermsPlugin {
 
         // remove all operators on startup if they're disabled
         if (!getConfiguration().get(ConfigKeys.OPS_ENABLED)) {
-            this.bootstrap.getServer().getScheduler().runTaskAsynchronously(this.bootstrap.getLoader(), () -> {
+            Runnable removeOps = () -> {
                 for (OfflinePlayer player : this.bootstrap.getServer().getOperators()) {
                     player.setOp(false);
                 }
-            });
+            };
+            if (FoliaUtil.isFolia()) {
+                FoliaSchedulerHelper.executeAsync(this.bootstrap.getLoader(), removeOps);
+            } else {
+                this.bootstrap.getServer().getScheduler().runTaskAsynchronously(this.bootstrap.getLoader(), removeOps);
+            }
         }
 
         // register autoop listener

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/inject/permissible/LuckPermsPermissible.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/inject/permissible/LuckPermsPermissible.java
@@ -28,6 +28,8 @@ package me.lucko.luckperms.bukkit.inject.permissible;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import me.lucko.luckperms.bukkit.LPBukkitPlugin;
+import me.lucko.luckperms.bukkit.util.FoliaSchedulerHelper;
+import me.lucko.luckperms.bukkit.util.FoliaUtil;
 import me.lucko.luckperms.bukkit.calculator.OpProcessor;
 import me.lucko.luckperms.bukkit.calculator.PermissionMapProcessor;
 import me.lucko.luckperms.common.cacheddata.result.TristateResult;
@@ -244,9 +246,13 @@ public class LuckPermsPermissible extends PermissibleBase {
         }
 
         LuckPermsPermissionAttachment attachment = addAttachment(plugin);
-        if (getPlugin().getBootstrap().getServer().getScheduler().scheduleSyncDelayedTask(plugin, attachment::remove, ticks) == -1) {
-            attachment.remove();
-            throw new RuntimeException("Could not add PermissionAttachment to " + this.player + " for plugin " + plugin.getDescription().getFullName() + ": Scheduler returned -1");
+        if (FoliaUtil.isFolia()) {
+            FoliaSchedulerHelper.runOnGlobalRegionDelayed(plugin, attachment::remove, ticks);
+        } else {
+            if (getPlugin().getBootstrap().getServer().getScheduler().scheduleSyncDelayedTask(plugin, attachment::remove, ticks) == -1) {
+                attachment.remove();
+                throw new RuntimeException("Could not add PermissionAttachment to " + this.player + " for plugin " + plugin.getDescription().getFullName() + ": Scheduler returned -1");
+            }
         }
         return attachment;
     }

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/listeners/BukkitConnectionListener.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/listeners/BukkitConnectionListener.java
@@ -26,6 +26,8 @@
 package me.lucko.luckperms.bukkit.listeners;
 
 import me.lucko.luckperms.bukkit.LPBukkitPlugin;
+import me.lucko.luckperms.bukkit.util.FoliaSchedulerHelper;
+import me.lucko.luckperms.bukkit.util.FoliaUtil;
 import me.lucko.luckperms.bukkit.inject.permissible.LuckPermsPermissible;
 import me.lucko.luckperms.bukkit.inject.permissible.PermissibleInjector;
 import me.lucko.luckperms.bukkit.util.PlayerLocaleUtil;
@@ -240,7 +242,7 @@ public class BukkitConnectionListener extends AbstractConnectionListener impleme
 
         // perform unhooking from bukkit objects 1 tick later.
         // this allows plugins listening after us on MONITOR to still have intact permissions data
-        this.plugin.getBootstrap().getServer().getScheduler().runTaskLater(this.plugin.getLoader(), () -> {
+        Runnable unhookTask = () -> {
             // Remove the custom permissible
             try {
                 PermissibleInjector.uninject(player, true);
@@ -253,7 +255,12 @@ public class BukkitConnectionListener extends AbstractConnectionListener impleme
             if (this.plugin.getConfiguration().get(ConfigKeys.AUTO_OP)) {
                 player.setOp(false);
             }
-        }, 1L);
+        };
+        if (FoliaUtil.isFolia()) {
+            FoliaSchedulerHelper.runOnGlobalRegionDelayed(this.plugin.getLoader(), unhookTask, 1L);
+        } else {
+            this.plugin.getBootstrap().getServer().getScheduler().runTaskLater(this.plugin.getLoader(), unhookTask, 1L);
+        }
     }
 
 }

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/messaging/PluginMessageMessenger.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/messaging/PluginMessageMessenger.java
@@ -27,6 +27,8 @@ package me.lucko.luckperms.bukkit.messaging;
 
 import com.google.common.collect.Iterables;
 import me.lucko.luckperms.bukkit.LPBukkitPlugin;
+import me.lucko.luckperms.bukkit.util.FoliaSchedulerHelper;
+import me.lucko.luckperms.bukkit.util.FoliaUtil;
 import me.lucko.luckperms.common.messaging.pluginmsg.AbstractPluginMessageMessenger;
 import net.luckperms.api.messenger.IncomingMessageConsumer;
 import net.luckperms.api.messenger.Messenger;
@@ -61,19 +63,32 @@ public class PluginMessageMessenger extends AbstractPluginMessageMessenger imple
 
     @Override
     protected void sendOutgoingMessage(byte[] buf) {
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                Collection<? extends Player> players = PluginMessageMessenger.this.plugin.getBootstrap().getServer().getOnlinePlayers();
+        if (FoliaUtil.isFolia()) {
+            FoliaSchedulerHelper.runOnGlobalRegionAtFixedRate(this.plugin.getLoader(), () -> {
+                Collection<? extends Player> players = this.plugin.getBootstrap().getServer().getOnlinePlayers();
                 Player p = Iterables.getFirst(players, null);
                 if (p == null) {
-                    return;
+                    return false;
                 }
 
-                p.sendPluginMessage(PluginMessageMessenger.this.plugin.getLoader(), CHANNEL, buf);
-                cancel();
-            }
-        }.runTaskTimer(this.plugin.getLoader(), 1L, 100L);
+                p.sendPluginMessage(this.plugin.getLoader(), CHANNEL, buf);
+                return true;
+            }, 1L, 100L);
+        } else {
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    Collection<? extends Player> players = PluginMessageMessenger.this.plugin.getBootstrap().getServer().getOnlinePlayers();
+                    Player p = Iterables.getFirst(players, null);
+                    if (p == null) {
+                        return;
+                    }
+
+                    p.sendPluginMessage(PluginMessageMessenger.this.plugin.getLoader(), CHANNEL, buf);
+                    cancel();
+                }
+            }.runTaskTimer(this.plugin.getLoader(), 1L, 100L);
+        }
     }
 
     @Override

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/util/FoliaSchedulerHelper.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/util/FoliaSchedulerHelper.java
@@ -1,0 +1,147 @@
+/*
+ * This file is part of LuckPerms, licensed under the MIT License.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+package me.lucko.luckperms.bukkit.util;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+
+import java.lang.reflect.Method;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+
+/**
+ * Reflection-based scheduling helper for the Folia region-aware scheduler API.
+ * Uses reflection to avoid compile-time dependency on modern Paper API.
+ */
+public final class FoliaSchedulerHelper {
+    private static final Method GET_GLOBAL_REGION_SCHEDULER;
+    private static final Method GET_ASYNC_SCHEDULER;
+    private static final Method GET_ENTITY_SCHEDULER;
+
+    private static final Method GLOBAL_EXECUTE;
+    private static final Method GLOBAL_RUN_DELAYED;
+    private static final Method GLOBAL_RUN_AT_FIXED_RATE;
+
+    private static final Method ASYNC_RUN_NOW;
+
+    private static final Method ENTITY_RUN;
+    private static final Method ENTITY_RUN_DELAYED;
+
+    static {
+        try {
+            Class<?> serverClass = Bukkit.getServer().getClass();
+
+            GET_GLOBAL_REGION_SCHEDULER = serverClass.getMethod("getGlobalRegionScheduler");
+            GET_ASYNC_SCHEDULER = serverClass.getMethod("getAsyncScheduler");
+            GET_ENTITY_SCHEDULER = Entity.class.getMethod("getScheduler");
+
+            Class<?> globalSchedulerClass = GET_GLOBAL_REGION_SCHEDULER.getReturnType();
+            GLOBAL_EXECUTE = globalSchedulerClass.getMethod("execute", Plugin.class, Runnable.class);
+            GLOBAL_RUN_DELAYED = globalSchedulerClass.getMethod("runDelayed", Plugin.class, Consumer.class, long.class);
+            GLOBAL_RUN_AT_FIXED_RATE = globalSchedulerClass.getMethod("runAtFixedRate", Plugin.class, Consumer.class, long.class, long.class);
+
+            Class<?> asyncSchedulerClass = GET_ASYNC_SCHEDULER.getReturnType();
+            ASYNC_RUN_NOW = asyncSchedulerClass.getMethod("runNow", Plugin.class, Consumer.class);
+
+            Class<?> entitySchedulerClass = GET_ENTITY_SCHEDULER.getReturnType();
+            ENTITY_RUN = entitySchedulerClass.getMethod("run", Plugin.class, Consumer.class, Runnable.class);
+            ENTITY_RUN_DELAYED = entitySchedulerClass.getMethod("runDelayed", Plugin.class, Consumer.class, Runnable.class, long.class);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private FoliaSchedulerHelper() {
+    }
+
+    public static void executeOnGlobalRegion(Plugin plugin, Runnable task) {
+        try {
+            Object scheduler = GET_GLOBAL_REGION_SCHEDULER.invoke(Bukkit.getServer());
+            GLOBAL_EXECUTE.invoke(scheduler, plugin, task);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void runOnGlobalRegionDelayed(Plugin plugin, Runnable task, long delayTicks) {
+        try {
+            Object scheduler = GET_GLOBAL_REGION_SCHEDULER.invoke(Bukkit.getServer());
+            Consumer<Object> consumer = t -> task.run();
+            GLOBAL_RUN_DELAYED.invoke(scheduler, plugin, consumer, delayTicks);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void runOnGlobalRegionAtFixedRate(Plugin plugin, BooleanSupplier task, long initialDelayTicks, long periodTicks) {
+        try {
+            Object scheduler = GET_GLOBAL_REGION_SCHEDULER.invoke(Bukkit.getServer());
+            Consumer<Object> consumer = scheduledTask -> {
+                if (task.getAsBoolean()) {
+                    try {
+                        scheduledTask.getClass().getMethod("cancel").invoke(scheduledTask);
+                    } catch (ReflectiveOperationException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            };
+            GLOBAL_RUN_AT_FIXED_RATE.invoke(scheduler, plugin, consumer, initialDelayTicks, periodTicks);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void executeOnEntity(Entity entity, Plugin plugin, Runnable task) {
+        try {
+            Object scheduler = GET_ENTITY_SCHEDULER.invoke(entity);
+            Consumer<Object> consumer = t -> task.run();
+            ENTITY_RUN.invoke(scheduler, plugin, consumer, (Runnable) null);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void runOnEntityDelayed(Entity entity, Plugin plugin, Runnable task, long delayTicks) {
+        try {
+            Object scheduler = GET_ENTITY_SCHEDULER.invoke(entity);
+            Consumer<Object> consumer = t -> task.run();
+            ENTITY_RUN_DELAYED.invoke(scheduler, plugin, consumer, (Runnable) null, delayTicks);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void executeAsync(Plugin plugin, Runnable task) {
+        try {
+            Object scheduler = GET_ASYNC_SCHEDULER.invoke(Bukkit.getServer());
+            Consumer<Object> consumer = t -> task.run();
+            ASYNC_RUN_NOW.invoke(scheduler, plugin, consumer);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/util/FoliaUtil.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/util/FoliaUtil.java
@@ -23,30 +23,26 @@
  *  SOFTWARE.
  */
 
-package me.lucko.luckperms.bukkit;
+package me.lucko.luckperms.bukkit.util;
 
-import me.lucko.luckperms.bukkit.util.FoliaSchedulerHelper;
-import me.lucko.luckperms.bukkit.util.FoliaUtil;
-import me.lucko.luckperms.common.plugin.scheduler.AbstractJavaScheduler;
-import me.lucko.luckperms.common.plugin.scheduler.SchedulerAdapter;
+public final class FoliaUtil {
+    private static final boolean FOLIA;
 
-import java.util.concurrent.Executor;
-
-public class BukkitSchedulerAdapter extends AbstractJavaScheduler implements SchedulerAdapter {
-    private final Executor sync;
-
-    public BukkitSchedulerAdapter(LPBukkitBootstrap bootstrap) {
-        super(bootstrap);
-        if (FoliaUtil.isFolia()) {
-            this.sync = r -> FoliaSchedulerHelper.executeOnGlobalRegion(bootstrap.getLoader(), r);
-        } else {
-            this.sync = r -> bootstrap.getServer().getScheduler().scheduleSyncDelayedTask(bootstrap.getLoader(), r);
+    static {
+        boolean folia;
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            folia = true;
+        } catch (ClassNotFoundException e) {
+            folia = false;
         }
+        FOLIA = folia;
     }
 
-    @Override
-    public Executor sync() {
-        return this.sync;
+    private FoliaUtil() {
     }
 
+    public static boolean isFolia() {
+        return FOLIA;
+    }
 }


### PR DESCRIPTION
Detect Folia at runtime and route scheduler calls to the appropriate region-aware scheduler API. Uses reflection to maintain compile-time compatibility with the existing Paper API dependency.

All direct BukkitScheduler usages are replaced with Folia-compatible alternatives when running on a Folia server, while preserving the original behavior on standard Bukkit/Spigot/Paper servers.