### PR TITLE
Fix NeoForge command source permission checks

### DIFF
--- a/common/minecraft/src/main/java/me/lucko/luckperms/common/minecraft/command/BrigadierInjector.java
+++ b/common/minecraft/src/main/java/me/lucko/luckperms/common/minecraft/command/BrigadierInjector.java
@@ -31,11 +31,8 @@ import com.mojang.brigadier.tree.LiteralCommandNode;
 import me.lucko.luckperms.common.graph.Graph;
 import me.lucko.luckperms.common.graph.TraversalAlgorithm;
 import me.lucko.luckperms.common.minecraft.MinecraftLuckPermsPlugin;
-import me.lucko.luckperms.common.model.User;
-import net.luckperms.api.query.QueryOptions;
 import net.luckperms.api.util.Tristate;
 import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.permissions.LevelBasedPermissionSet;
 
 import java.lang.reflect.Field;
@@ -140,19 +137,10 @@ public final class BrigadierInjector {
 
         @Override
         public boolean test(CommandSourceStack source) {
-            if (source.getEntity() instanceof ServerPlayer player) {
+            Tristate state = this.plugin.getSenderFactory().wrap(source).getPermissionValue(this.permission);
 
-                User user = this.plugin.getUserManager().getIfLoaded(player.getUUID());
-                if (user == null) {
-                    return false;
-                }
-
-                QueryOptions queryOptions = this.plugin.getContextManager().getQueryOptions(player);
-                Tristate state = user.getCachedData().getPermissionData(queryOptions).checkPermission(this.permission);
-
-                if (state != Tristate.UNDEFINED) {
-                    return state.asBoolean() && this.delegate.test(source.withPermission(LevelBasedPermissionSet.OWNER));
-                }
+            if (state != Tristate.UNDEFINED) {
+                return state.asBoolean() && this.delegate.test(source.withPermission(LevelBasedPermissionSet.OWNER));
             }
 
             return this.delegate.test(source);

--- a/common/minecraft/src/main/java/me/lucko/luckperms/common/minecraft/command/BrigadierInjector.java
+++ b/common/minecraft/src/main/java/me/lucko/luckperms/common/minecraft/command/BrigadierInjector.java
@@ -137,7 +137,13 @@ public final class BrigadierInjector {
 
         @Override
         public boolean test(CommandSourceStack source) {
-            Tristate state = this.plugin.getSenderFactory().wrap(source).getPermissionValue(this.permission);
+            var senderFactory = this.plugin.getSenderFactory();
+            if (senderFactory == null) {
+                // This can happen during, uh, datapack loading period.
+                // If that happens, we have no choice but rely on the fallback.
+                return this.delegate.test(source);
+            }
+            Tristate state = senderFactory.wrap(source).getPermissionValue(this.permission);
 
             if (state != Tristate.UNDEFINED) {
                 return state.asBoolean() && this.delegate.test(source.withPermission(LevelBasedPermissionSet.OWNER));

--- a/neoforge/gradle.properties
+++ b/neoforge/gradle.properties
@@ -1,2 +1,2 @@
 minecraftVersion=26.1
-neoForgeVersion=26.1.0.1-beta
+neoForgeVersion=26.1.2.50-beta

--- a/neoforge/src/main/java/me/lucko/luckperms/neoforge/NeoForgeSenderFactory.java
+++ b/neoforge/src/main/java/me/lucko/luckperms/neoforge/NeoForgeSenderFactory.java
@@ -25,17 +25,18 @@
 
 package me.lucko.luckperms.neoforge;
 
+import com.mojang.authlib.GameProfile;
 import me.lucko.luckperms.common.cacheddata.result.TristateResult;
 import me.lucko.luckperms.common.minecraft.MinecraftSenderFactory;
 import me.lucko.luckperms.common.model.User;
 import me.lucko.luckperms.common.query.QueryOptionsImpl;
 import me.lucko.luckperms.common.verbose.VerboseCheckTarget;
 import me.lucko.luckperms.common.verbose.event.CheckOrigin;
-import net.luckperms.api.query.QueryOptions;
 import net.luckperms.api.util.Tristate;
 import net.minecraft.commands.CommandSource;
 import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Optional;
 
 public class NeoForgeSenderFactory extends MinecraftSenderFactory<LPNeoForgePlugin> {
     public NeoForgeSenderFactory(LPNeoForgePlugin plugin) {
@@ -49,14 +50,14 @@ public class NeoForgeSenderFactory extends MinecraftSenderFactory<LPNeoForgePlug
 
     @Override
     protected Tristate getPermissionValue(CommandSourceStack commandSource, String node) {
-        if (commandSource.getEntity() instanceof ServerPlayer player) {
-            User user = getPlugin().getUserManager().getIfLoaded(player.getUUID());
+        Optional<GameProfile> sourceProfile = commandSource.getSourceProfile();
+        if (sourceProfile.isPresent()) {
+            User user = getPlugin().getUserManager().getIfLoaded(sourceProfile.get().id());
             if (user == null) {
                 return Tristate.UNDEFINED;
             }
 
-            QueryOptions queryOptions = getPlugin().getContextManager().getQueryOptions(player);
-            return user.getCachedData().getPermissionData(queryOptions).checkPermission(node, CheckOrigin.PLATFORM_API_HAS_PERMISSION).result();
+            return user.getCachedData().getPermissionData().checkPermission(node, CheckOrigin.PLATFORM_API_HAS_PERMISSION).result();
         }
 
         VerboseCheckTarget target = VerboseCheckTarget.internal(commandSource.getTextName());


### PR DESCRIPTION
This PR depends on neoforged/NeoForge#3154, which introduced `CommandSourceStack#getSourceProfile` and solved the platform-side issue where the actual command source profile was not available from `CommandSourceStack`. Without it, mods had to infer the player from `getEntity()`, which is incorrect for commands like `execute as Bob run ...`.

This PR updates NeoForge permission checks to use the source profile instead of the command entity. This prevents command permissions from being checked against the target entity selected by `execute as`, rather than the actual command executor.