### PR TITLE
Add bulk user lookup by uuid method to the API

### DIFF
--- a/api/src/main/java/net/luckperms/api/model/user/UserManager.java
+++ b/api/src/main/java/net/luckperms/api/model/user/UserManager.java
@@ -82,6 +82,15 @@ public interface UserManager {
     }
 
     /**
+     * Loads multiple users from the plugin's storage provider into memory.
+     *
+     * @param uniqueIds the uuids of the users to load
+     * @return a future for an unmodifiable map of loaded users
+     * @throws NullPointerException if the uuid set is null
+     */
+    @NonNull CompletableFuture<@Unmodifiable Map<UUID, User>> loadUsers(@NonNull Set<@NonNull UUID> uniqueIds);
+
+    /**
      * Uses the LuckPerms cache to find a uuid for the given username.
      *
      * <p>This lookup is case insensitive.</p>

--- a/common/src/main/java/me/lucko/luckperms/common/api/implementation/ApiUserManager.java
+++ b/common/src/main/java/me/lucko/luckperms/common/api/implementation/ApiUserManager.java
@@ -49,6 +49,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 public class ApiUserManager extends ApiAbstractManager<User, net.luckperms.api.model.user.User, UserManager<?>> implements net.luckperms.api.model.user.UserManager {
     public ApiUserManager(LuckPermsPlugin plugin, UserManager<?> handle) {
@@ -74,6 +75,18 @@ public class ApiUserManager extends ApiAbstractManager<User, net.luckperms.api.m
 
         return this.plugin.getStorage().loadUser(uniqueId, username)
                 .thenApply(this::proxyAndRegisterUsage);
+    }
+
+    @Override
+    public @NonNull CompletableFuture<Map<UUID, net.luckperms.api.model.user.User>> loadUsers(@NonNull Set<@NonNull UUID> uniqueIds) {
+        Objects.requireNonNull(uniqueIds, "uuid set");
+
+        if (uniqueIds.isEmpty()) {
+            return CompletableFuture.completedFuture(Map.of());
+        }
+
+        return this.plugin.getStorage().loadUsers(uniqueIds)
+                .thenApply(map -> map.entrySet().stream().collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, entry -> this.proxyAndRegisterUsage(entry.getValue()))));
     }
 
     @Override


### PR DESCRIPTION
Exposes the Storage#loadUsers method in the API to allow loading many users at the same time.