### PR TITLE
Update MongoStorage to use exportChanges

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/storage/implementation/mongodb/MongoStorage.java
+++ b/common/src/main/java/me/lucko/luckperms/common/storage/implementation/mongodb/MongoStorage.java
@@ -38,6 +38,8 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.Sorts;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.Updates;
 import me.lucko.luckperms.common.actionlog.LogPage;
 import me.lucko.luckperms.common.actionlog.LoggedAction;
 import me.lucko.luckperms.common.actionlog.filter.ActionFilterMongoBuilder;
@@ -59,6 +61,7 @@ import me.lucko.luckperms.common.storage.implementation.StorageImplementation;
 import me.lucko.luckperms.common.storage.misc.NodeEntry;
 import me.lucko.luckperms.common.storage.misc.PlayerSaveResultImpl;
 import me.lucko.luckperms.common.storage.misc.StorageCredentials;
+import me.lucko.luckperms.common.util.Difference;
 import me.lucko.luckperms.common.util.HostAndPort;
 import me.lucko.luckperms.common.util.Iterators;
 import net.luckperms.api.actionlog.Action;
@@ -266,7 +269,7 @@ public class MongoStorage implements StorageImplementation {
 
                 boolean updatedUsername = user.getUsername().isPresent() && (name == null || !user.getUsername().get().equalsIgnoreCase(name));
                 if (updatedUsername | user.auditTemporaryNodes()) {
-                    c.replaceOne(Filters.eq("_id", user.getUniqueId()), userToDoc(user));
+                    saveUser(user);
                 }
             } else {
                 if (this.plugin.getUserManager().isNonDefaultUser(user)) {
@@ -292,11 +295,40 @@ public class MongoStorage implements StorageImplementation {
     @Override
     public void saveUser(User user) {
         MongoCollection<Document> c = this.database.getCollection(this.prefix + "users");
-        user.normalData().discardChanges();
-        if (!this.plugin.getUserManager().isNonDefaultUser(user)) {
+
+        Difference<Node> changes = user.normalData().exportChanges(results -> {
+            if (this.plugin.getUserManager().isNonDefaultUser(user)) {
+                return true;
+            }
+
+            // if the only change is adding the default node, we don't need to export
+            if (results.getChanges().size() == 1) {
+                Difference.Change<Node> onlyChange = results.getChanges().iterator().next();
+                return !(onlyChange.type() == Difference.ChangeType.ADD && this.plugin.getUserManager().isDefaultNode(onlyChange.value()));
+            }
+
+            return true;
+        });
+
+        // if the user only has the default group, delete their data
+        boolean isDefaultUser = !this.plugin.getUserManager().isNonDefaultUser(user);
+        if (changes != null && isDefaultUser) {
+            user.normalData().addDefaultNodeToChangeSet();
+            changes = null;
+        }
+
+        if (changes == null) {
             c.deleteOne(Filters.eq("_id", user.getUniqueId()));
-        } else {
-            c.replaceOne(Filters.eq("_id", user.getUniqueId()), userToDoc(user), new ReplaceOptions().upsert(true));
+            return;
+        }
+
+        List<Bson> updates = nodeChangesToUpdates(changes);
+        updates.add(Updates.combine(
+                Updates.set("name", user.getUsername().orElse("null")),
+                Updates.set("primaryGroup", user.getPrimaryGroup().getStoredValue().orElse(GroupManager.DEFAULT_GROUP_NAME))
+        ));
+        for (Bson update : updates) {
+            c.updateOne(Filters.eq("_id", user.getUniqueId()), update, new UpdateOptions().upsert(true));
         }
     }
 
@@ -342,11 +374,11 @@ public class MongoStorage implements StorageImplementation {
         Group group = this.plugin.getGroupManager().getOrMake(name);
         MongoCollection<Document> c = this.database.getCollection(this.prefix + "groups");
         try (MongoCursor<Document> cursor = c.find(Filters.eq("_id", group.getName())).iterator()) {
-            if (cursor.hasNext()) {
+            if (!cursor.hasNext()) {
+                c.insertOne(new Document("_id", group.getName()));
+            } else {
                 Document d = cursor.next();
                 group.loadNodesFromStorage(nodesFromDoc(d));
-            } else {
-                c.insertOne(groupToDoc(group));
             }
         }
         return group;
@@ -388,8 +420,12 @@ public class MongoStorage implements StorageImplementation {
     @Override
     public void saveGroup(Group group) {
         MongoCollection<Document> c = this.database.getCollection(this.prefix + "groups");
-        group.normalData().discardChanges();
-        c.replaceOne(Filters.eq("_id", group.getName()), groupToDoc(group), new ReplaceOptions().upsert(true));
+        Difference<Node> changes = group.normalData().exportChanges(results -> true);
+
+        List<Bson> updates = nodeChangesToUpdates(changes);
+        for (Bson update : updates) {
+            c.updateOne(Filters.eq("_id", group.getName()), update, new UpdateOptions().upsert(true));
+        }
     }
 
     @Override
@@ -553,17 +589,6 @@ public class MongoStorage implements StorageImplementation {
         }
     }
 
-    private static Document userToDoc(User user) {
-        List<Document> nodes = user.normalData().asList().stream()
-                .map(MongoStorage::nodeToDoc)
-                .collect(Collectors.toList());
-
-        return new Document("_id", user.getUniqueId())
-                .append("name", user.getUsername().orElse("null"))
-                .append("primaryGroup", user.getPrimaryGroup().getStoredValue().orElse(GroupManager.DEFAULT_GROUP_NAME))
-                .append("permissions", nodes);
-    }
-
     private static List<Node> nodesFromDoc(Document document) {
         List<Node> nodes = new ArrayList<>();
         if (document.containsKey("permissions") && document.get("permissions") instanceof List) {
@@ -579,16 +604,27 @@ public class MongoStorage implements StorageImplementation {
         return nodes;
     }
 
-    private static Document groupToDoc(Group group) {
-        List<Document> nodes = group.normalData().asList().stream()
-                .map(MongoStorage::nodeToDoc)
-                .collect(Collectors.toList());
-
-        return new Document("_id", group.getName()).append("permissions", nodes);
-    }
-
     private static Document trackToDoc(Track track) {
         return new Document("_id", track.getName()).append("groups", track.getGroups());
+    }
+
+    private static List<Bson> nodeChangesToUpdates(Difference<Node> changes) {
+        List<Bson> updates = new ArrayList<>();
+
+        Set<Node> removed = changes.getRemoved();
+        Set<Node> added = changes.getAdded();
+
+        if (!removed.isEmpty()) {
+            List<Document> docs = removed.stream().map(MongoStorage::nodeToDoc).collect(Collectors.toList());
+            updates.add(Updates.pullAll("permissions", docs));
+        }
+
+        if (!added.isEmpty()) {
+            List<Document> docs = added.stream().map(MongoStorage::nodeToDoc).collect(Collectors.toList());
+            updates.add(Updates.pushEach("permissions", docs));
+        }
+
+        return updates;
     }
 
     @VisibleForTesting

--- a/common/src/test/java/me/lucko/luckperms/common/storage/AbstractStorageTest.java
+++ b/common/src/test/java/me/lucko/luckperms/common/storage/AbstractStorageTest.java
@@ -285,24 +285,25 @@ public abstract class AbstractStorageTest {
 
         Group group = this.storage.createAndLoadGroup("test");
 
-        group.normalData().add(Permission.builder()
+        Node node1 = Permission.builder()
                 .permission("test.1")
                 .withContext("server", "test")
-                .build()
-        );
-        group.normalData().add(Permission.builder()
+                .build();
+        Node node2 = Permission.builder()
                 .permission("test.2")
                 .withContext("world", "test")
-                .build()
-        );
-        group.normalData().add(Permission.builder()
+                .build();
+        Node node3 = Permission.builder()
                 .permission("test.3")
                 .expiry(1, TimeUnit.HOURS)
                 .withContext("server", "test")
                 .withContext("world", "test")
                 .withContext("hello", "test")
-                .build()
-        );
+                .build();
+
+        group.normalData().add(node1);
+        group.normalData().add(node2);
+        group.normalData().add(node3);
 
         Set<Node> nodes = group.normalData().asSet();
         assertEquals(3, nodes.size());
@@ -314,6 +315,27 @@ public abstract class AbstractStorageTest {
         assertNotNull(loaded);
         assertNotSame(group, loaded);
         assertEquals(nodes, loaded.normalData().asSet());
+
+        // now edit the loaded group - removing a node and adding a new one - and ensure
+        // the resulting diff (produced via RecordedNodeMap#exportChanges) is persisted correctly
+        Node node4 = Permission.builder()
+                .permission("test.4")
+                .withContext("server", "test2")
+                .build();
+
+        loaded.normalData().remove(node2);
+        loaded.normalData().add(node4);
+
+        Set<Node> editedNodes = loaded.normalData().asSet();
+        assertEquals(ImmutableSet.of(node1, node3, node4), editedNodes);
+
+        this.storage.saveGroup(loaded);
+        groupManager.unload("test");
+
+        Group reloaded = this.storage.loadGroup("test").orElse(null);
+        assertNotNull(reloaded);
+        assertNotSame(loaded, reloaded);
+        assertEquals(editedNodes, reloaded.normalData().asSet());
     }
 
     @Test
@@ -356,6 +378,25 @@ public abstract class AbstractStorageTest {
         // reload user data from the db and assert that it is unchanged
         user = this.storage.loadUser(exampleUniqueId, exampleUsername);
         assertEquals(ImmutableSet.of(defaultGroupNode, examplePermission), user.normalData().asSet());
+
+        // now edit the user - removing a node and adding a new one - and ensure the
+        // resulting diff (produced via RecordedNodeMap#exportChanges) is persisted correctly
+        PermissionNode anotherPermission = Permission.builder()
+                .permission("test.2")
+                .withContext("world", "test")
+                .build();
+
+        user.normalData().remove(examplePermission);
+        user.normalData().add(anotherPermission);
+
+        Set<Node> editedNodes = user.normalData().asSet();
+        assertEquals(ImmutableSet.of(defaultGroupNode, anotherPermission), editedNodes);
+
+        this.storage.saveUser(user);
+        assertTrue(this.storage.getUniqueUsers().contains(exampleUniqueId));
+
+        user = this.storage.loadUser(exampleUniqueId, exampleUsername);
+        assertEquals(editedNodes, user.normalData().asSet());
     }
 
 }


### PR DESCRIPTION
Updates MongoStorage to use the Difference/exportChanges feature to save User/Group changes, similar to the SQL implementations. This avoids overwriting changes written by another instance between load/save calls.

Another fix towards the root cause identified in #4283