### PR TITLE
Validate page number before constructing PageParameters in log commands

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/commands/log/LogGroupHistory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/commands/log/LogGroupHistory.java
@@ -59,10 +59,14 @@ public class LogGroupHistory extends ChildCommand<Void> {
             return;
         }
 
-        PageParameters pageParams = new PageParameters(ENTRIES_PER_PAGE, args.getIntOrDefault(1, 1));
-        LogPage log = plugin.getStorage().getLogPage(ActionFilters.group(group), pageParams).join();
+        int page = args.getIntOrDefault(1, 1);
+        if (page < 1) {
+            Message.LOG_INVALID_PAGE_RANGE.send(sender, 1);
+            return;
+        }
 
-        int page = pageParams.pageNumber();
+        PageParameters pageParams = new PageParameters(ENTRIES_PER_PAGE, page);
+        LogPage log = plugin.getStorage().getLogPage(ActionFilters.group(group), pageParams).join();
         int maxPage = pageParams.getMaxPage(log.getTotalEntries());
 
         if (log.getTotalEntries() == 0) {
@@ -70,7 +74,7 @@ public class LogGroupHistory extends ChildCommand<Void> {
             return;
         }
 
-        if (page < 1 || page > maxPage) {
+        if (page > maxPage) {
             Message.LOG_INVALID_PAGE_RANGE.send(sender, maxPage);
             return;
         }

--- a/common/src/main/java/me/lucko/luckperms/common/commands/log/LogRecent.java
+++ b/common/src/main/java/me/lucko/luckperms/common/commands/log/LogRecent.java
@@ -70,6 +70,11 @@ public class LogRecent extends ChildCommand<Void> {
             }
         }
 
+        if (page < 1) {
+            Message.LOG_INVALID_PAGE_RANGE.send(sender, 1);
+            return;
+        }
+
         PageParameters pageParams = new PageParameters(ENTRIES_PER_PAGE, page);
         LogPage log = plugin.getStorage().getLogPage(uuid == null ? ActionFilters.all() : ActionFilters.source(uuid), pageParams).join();
 
@@ -79,7 +84,7 @@ public class LogRecent extends ChildCommand<Void> {
             return;
         }
 
-        if (page < 1 || page > maxPage) {
+        if (page > maxPage) {
             Message.LOG_INVALID_PAGE_RANGE.send(sender, maxPage);
             return;
         }

--- a/common/src/main/java/me/lucko/luckperms/common/commands/log/LogSearch.java
+++ b/common/src/main/java/me/lucko/luckperms/common/commands/log/LogSearch.java
@@ -60,6 +60,12 @@ public class LogSearch extends ChildCommand<Void> {
         }
 
         final String query = String.join(" ", args);
+
+        if (page < 1) {
+            Message.LOG_INVALID_PAGE_RANGE.send(sender, 1);
+            return;
+        }
+
         PageParameters pageParams = new PageParameters(ENTRIES_PER_PAGE, page);
         LogPage log = plugin.getStorage().getLogPage(ActionFilters.search(query), pageParams).join();
 
@@ -69,7 +75,7 @@ public class LogSearch extends ChildCommand<Void> {
             return;
         }
 
-        if (page < 1 || page > maxPage) {
+        if (page > maxPage) {
             Message.LOG_INVALID_PAGE_RANGE.send(sender, maxPage);
             return;
         }

--- a/common/src/main/java/me/lucko/luckperms/common/commands/log/LogTrackHistory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/commands/log/LogTrackHistory.java
@@ -58,10 +58,14 @@ public class LogTrackHistory extends ChildCommand<Void> {
             Message.TRACK_INVALID_ENTRY.send(sender, track);
             return;
         }
-        PageParameters pageParams = new PageParameters(ENTRIES_PER_PAGE, args.getIntOrDefault(1, 1));
-        LogPage log = plugin.getStorage().getLogPage(ActionFilters.track(track), pageParams).join();
+        int page = args.getIntOrDefault(1, 1);
+        if (page < 1) {
+            Message.LOG_INVALID_PAGE_RANGE.send(sender, 1);
+            return;
+        }
 
-        int page = pageParams.pageNumber();
+        PageParameters pageParams = new PageParameters(ENTRIES_PER_PAGE, page);
+        LogPage log = plugin.getStorage().getLogPage(ActionFilters.track(track), pageParams).join();
         int maxPage = pageParams.getMaxPage(log.getTotalEntries());
 
         if (log.getTotalEntries() == 0) {
@@ -69,7 +73,7 @@ public class LogTrackHistory extends ChildCommand<Void> {
             return;
         }
 
-        if (page < 1 || page > maxPage) {
+        if (page > maxPage) {
             Message.LOG_INVALID_PAGE_RANGE.send(sender, maxPage);
             return;
         }

--- a/common/src/main/java/me/lucko/luckperms/common/commands/log/LogUserHistory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/commands/log/LogUserHistory.java
@@ -55,10 +55,14 @@ public class LogUserHistory extends ChildCommand<Void> {
             return;
         }
 
-        PageParameters pageParams = new PageParameters(ENTRIES_PER_PAGE, args.getIntOrDefault(1, 1));
-        LogPage log = plugin.getStorage().getLogPage(ActionFilters.user(uuid), pageParams).join();
+        int page = args.getIntOrDefault(1, 1);
+        if (page < 1) {
+            Message.LOG_INVALID_PAGE_RANGE.send(sender, 1);
+            return;
+        }
 
-        int page = pageParams.pageNumber();
+        PageParameters pageParams = new PageParameters(ENTRIES_PER_PAGE, page);
+        LogPage log = plugin.getStorage().getLogPage(ActionFilters.user(uuid), pageParams).join();
         int maxPage = pageParams.getMaxPage(log.getTotalEntries());
 
         if (log.getTotalEntries() == 0) {
@@ -66,7 +70,7 @@ public class LogUserHistory extends ChildCommand<Void> {
             return;
         }
 
-        if (page < 1 || page > maxPage) {
+        if (page > maxPage) {
             Message.LOG_INVALID_PAGE_RANGE.send(sender, maxPage);
             return;
         }


### PR DESCRIPTION
All five log commands (`/lp log recent`, `/lp log userhistory`, `/lp log grouphistory`, `/lp log trackhistory`, `/lp log search`) construct a `PageParameters` instance with a user-supplied page number before validating it. Since `PageParameters` throws `IllegalArgumentException` if `pageNumber < 1`, passing a negative or zero page number to any of these commands results in an unhandled exception and a stack trace shown to the sender, instead of the intended `LOG_INVALID_PAGE_RANGE` message.

The `page < 1 || page > maxPage` check already exists in each command, but it is placed **after** the `PageParameters` construction, so it is unreachable when `page < 1`.

## Steps to reproduce

Any of the following commands trigger the exception:

- `/lp log recent -1`
- `/lp log recent 0`
- `/lp log userhistory <player> -1`
- `/lp log grouphistory <group> 0`
- `/lp log trackhistory <track> -1`
- `/lp log search <query> -1`

## Fix

For each of the five commands:

1. Extract the page number **before** constructing `PageParameters`.
2. If `page < 1`, send `LOG_INVALID_PAGE_RANGE` and return early.
3. Simplify the later `page < 1 || page > maxPage` check to just `page > maxPage`, since `page >= 1` is now guaranteed.

## Notes

- No public API changes.
- No behavior change for valid page numbers.
- Behavior change for `page < 1`: sender now sees `LOG_INVALID_PAGE_RANGE` (as originally intended) instead of a stack trace.
- The `LOG_INVALID_PAGE_RANGE` message is called with `1` as the max page when the page is too low, since the actual max page isn't known yet at that point.