### PR TITLE
Fix inverted Audience check in PaperAdventureBridge

### DIFF
--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/util/PaperAdventureBridge.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/util/PaperAdventureBridge.java
@@ -55,7 +55,7 @@ public final class PaperAdventureBridge {
         Class<?> componentClass = Class.forName(adventurePkg + "text.Component");
         Class<?> serializerClass = Class.forName(adventurePkg + "text.serializer.gson.GsonComponentSerializer");
 
-        if (CommandSender.class.isAssignableFrom(audienceClass)) {
+        if (!audienceClass.isAssignableFrom(CommandSender.class)) {
             throw new IllegalStateException("CommandSender does not implement Audience");
         }
 


### PR DESCRIPTION
The guard added in #4292 tests the wrong direction, so it never fires:

```java
if (CommandSender.class.isAssignableFrom(audienceClass)) {
    throw new IllegalStateException("CommandSender does not implement Audience");
}
```

`A.isAssignableFrom(B)` is true when `B` is a subtype of `A`, so this asks whether `Audience` is a subtype of `CommandSender`. That is never true, and the message states the opposite of the condition being tested. The check that is meant to reject platforms without native Adventure support therefore always passes.

### Why that matters

`Class.forName("net.kyori.adventure.audience.Audience")` succeeding does not imply the server's `CommandSender` implements it. LuckPerms relocates its own copy of Adventure (which is why the lookup string is split), but on Bukkit the plugin classloader also resolves classes loaded by *other* plugins, so any plugin on the server that ships Adventure unrelocated makes all three `Class.forName` calls succeed.

With the guard inoperative, `PaperAdventureBridge.INSTANCE` is non-null, `BukkitSenderFactory.create` picks `PaperBridgeBukkitSenderFactory`, and the first message sent is the startup banner in `AbstractLuckPermsPlugin#enable`:

```
Error occurred while enabling LuckPerms v5.5.71
java.lang.IllegalArgumentException: object is not an instance of declaring class
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(...)
    at me.lucko.luckperms.bukkit.util.PaperAdventureBridge.sendMessage(PaperAdventureBridge.java:78)
    at me.lucko.luckperms.bukkit.BukkitSenderFactory$PaperBridgeBukkitSenderFactory.sendMessage0(BukkitSenderFactory.java:129)
    ...
    at me.lucko.luckperms.common.plugin.AbstractLuckPermsPlugin.enable(AbstractLuckPermsPlugin.java:158)
```

`IllegalArgumentException` is unchecked, so `catch (ReflectiveOperationException)` in `sendMessage` does not apply and it propagates out of `enable()` — the plugin fails to enable entirely rather than falling back to adventure-platform.

Observed on a 1.8.8 server running 5.5.71, but nothing about the failure is version specific: it needs only a `CommandSender` that does not implement `Audience` plus any plugin exposing unrelocated `net.kyori.adventure`.

### The change

```java
if (!audienceClass.isAssignableFrom(CommandSender.class)) {
    throw new IllegalStateException("CommandSender does not implement Audience");
}
```

On Paper this is unchanged behaviour: `CommandSender extends Audience`, and `PluginClassLoader` delegates to the parent first, so `audienceClass` is the server's own `Audience`. Where the assertion does not hold, the constructor now throws as it was meant to and `create` falls back to `AdventurePlatformBukkitSenderFactory`.

I have kept this to the one line. Happy to follow up separately with a change that prevents an unexpected runtime exception from the bridge failing enable outright, but that felt like a design call rather than part of this fix.
