### PR TITLE
Fix spelling and punctuation errors across codebase

### DIFF
--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -457,7 +457,7 @@ inheritance-traversal-algorithm: depth-first-pre-order
 # the inheritance tree.
 #
 # Effectively when this setting is 'true': the tree is flattened, and rules applied afterwards,
-# and when this setting is 'false':, the rules are just applied during each step of the traversal.
+# and when this setting is 'false': the rules are just applied during each step of the traversal.
 post-traversal-inheritance-sort: false
 
 # Defines the mode used to determine whether a set of contexts are satisfied.

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -465,7 +465,7 @@ inheritance-traversal-algorithm: depth-first-pre-order
 # the inheritance tree.
 #
 # Effectively when this setting is 'true': the tree is flattened, and rules applied afterwards,
-# and when this setting is 'false':, the rules are just applied during each step of the traversal.
+# and when this setting is 'false': the rules are just applied during each step of the traversal.
 post-traversal-inheritance-sort: false
 
 # Defines the mode used to determine whether a set of contexts are satisfied.

--- a/common/src/main/java/me/lucko/luckperms/common/locale/Message.java
+++ b/common/src/main/java/me/lucko/luckperms/common/locale/Message.java
@@ -4034,7 +4034,7 @@ public interface Message {
     );
 
     Args0 EXPORT_FILE_FAILURE = () -> prefixed(translatable()
-            // "&cAn unexpected error occured whilst writing to the file."
+            // "&cAn unexpected error occurred whilst writing to the file."
             .key("luckperms.command.export.file-unexpected-error-writing")
             .color(RED)
             .append(FULL_STOP)
@@ -4083,7 +4083,7 @@ public interface Message {
     );
 
     Args0 IMPORT_FILE_READ_FAILURE = () -> prefixed(text()
-            // "&cAn unexpected error occured whilst reading from the import file. (is it the correct format?)"
+            // "&cAn unexpected error occurred whilst reading from the import file. (is it the correct format?)"
             .color(RED)
             .append(translatable("luckperms.command.import.file.unexpected-error-reading"))
             .append(FULL_STOP)

--- a/fabric/src/main/resources/luckperms.conf
+++ b/fabric/src/main/resources/luckperms.conf
@@ -469,7 +469,7 @@ inheritance-traversal-algorithm = "depth-first-pre-order"
 # the inheritance tree.
 #
 # Effectively when this setting is 'true': the tree is flattened, and rules applied afterwards,
-# and when this setting is 'false':, the rules are just applied during each step of the traversal.
+# and when this setting is 'false': the rules are just applied during each step of the traversal.
 post-traversal-inheritance-sort = false
 
 # Defines the mode used to determine whether a set of contexts are satisfied.

--- a/forge/src/main/resources/luckperms.conf
+++ b/forge/src/main/resources/luckperms.conf
@@ -467,7 +467,7 @@ inheritance-traversal-algorithm = "depth-first-pre-order"
 # the inheritance tree.
 #
 # Effectively when this setting is 'true': the tree is flattened, and rules applied afterwards,
-# and when this setting is 'false':, the rules are just applied during each step of the traversal.
+# and when this setting is 'false': the rules are just applied during each step of the traversal.
 post-traversal-inheritance-sort = false
 
 # Defines the mode used to determine whether a set of contexts are satisfied.

--- a/hytale/src/main/resources/config.yml
+++ b/hytale/src/main/resources/config.yml
@@ -447,7 +447,7 @@ inheritance-traversal-algorithm: depth-first-pre-order
 # the inheritance tree.
 #
 # Effectively when this setting is 'true': the tree is flattened, and rules applied afterwards,
-# and when this setting is 'false':, the rules are just applied during each step of the traversal.
+# and when this setting is 'false': the rules are just applied during each step of the traversal.
 post-traversal-inheritance-sort: false
 
 # Defines the mode used to determine whether a set of contexts are satisfied.

--- a/neoforge/src/main/resources/luckperms.conf
+++ b/neoforge/src/main/resources/luckperms.conf
@@ -467,7 +467,7 @@ inheritance-traversal-algorithm = "depth-first-pre-order"
 # the inheritance tree.
 #
 # Effectively when this setting is 'true': the tree is flattened, and rules applied afterwards,
-# and when this setting is 'false':, the rules are just applied during each step of the traversal.
+# and when this setting is 'false': the rules are just applied during each step of the traversal.
 post-traversal-inheritance-sort = false
 
 # Defines the mode used to determine whether a set of contexts are satisfied.

--- a/nukkit/src/main/resources/config.yml
+++ b/nukkit/src/main/resources/config.yml
@@ -452,7 +452,7 @@ inheritance-traversal-algorithm: depth-first-pre-order
 # the inheritance tree.
 #
 # Effectively when this setting is 'true': the tree is flattened, and rules applied afterwards,
-# and when this setting is 'false':, the rules are just applied during each step of the traversal.
+# and when this setting is 'false': the rules are just applied during each step of the traversal.
 post-traversal-inheritance-sort: false
 
 # Defines the mode used to determine whether a set of contexts are satisfied.

--- a/sponge/src/main/resources/luckperms.conf
+++ b/sponge/src/main/resources/luckperms.conf
@@ -469,7 +469,7 @@ inheritance-traversal-algorithm = "depth-first-pre-order"
 # the inheritance tree.
 #
 # Effectively when this setting is 'true': the tree is flattened, and rules applied afterwards,
-# and when this setting is 'false':, the rules are just applied during each step of the traversal.
+# and when this setting is 'false': the rules are just applied during each step of the traversal.
 post-traversal-inheritance-sort = false
 
 # Defines the mode used to determine whether a set of contexts are satisfied.

--- a/standalone/src/main/resources/config.yml
+++ b/standalone/src/main/resources/config.yml
@@ -442,7 +442,7 @@ inheritance-traversal-algorithm: depth-first-pre-order
 # the inheritance tree.
 #
 # Effectively when this setting is 'true': the tree is flattened, and rules applied afterwards,
-# and when this setting is 'false':, the rules are just applied during each step of the traversal.
+# and when this setting is 'false': the rules are just applied during each step of the traversal.
 post-traversal-inheritance-sort: false
 
 # Defines the mode used to determine whether a set of contexts are satisfied.

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -456,7 +456,7 @@ inheritance-traversal-algorithm: depth-first-pre-order
 # the inheritance tree.
 #
 # Effectively when this setting is 'true': the tree is flattened, and rules applied afterwards,
-# and when this setting is 'false':, the rules are just applied during each step of the traversal.
+# and when this setting is 'false': the rules are just applied during each step of the traversal.
 post-traversal-inheritance-sort: false
 
 # Defines the mode used to determine whether a set of contexts are satisfied.


### PR DESCRIPTION
## Summary
- Fix "occured" → "occurred" typo in Message.java (2 instances in comments)
- Remove extra comma after 'false': in configuration files (10 instances across all platform configs)

## Changed files
- common/src/main/java/me/lucko/luckperms/common/locale/Message.java
- bungee/src/main/resources/config.yml
- bukkit/src/main/resources/config.yml
- fabric/src/main/resources/luckperms.conf
- forge/src/main/resources/luckperms.conf
- neoforge/src/main/resources/luckperms.conf
- nukkit/src/main/resources/config.yml
- velocity/src/main/resources/config.yml
- sponge/src/main/resources/luckperms.conf
- standalone/src/main/resources/config.yml
- hytale/src/main/resources/config.yml

## Test plan
- [x] Spelling corrections verified in source code
- [x] Punctuation fixes verified in configuration files
- [x] All changes are documentation/comment only, no functional impact