### PR TITLE
Prevent NPE in PostgresMessenger when SocketException message is null

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/messaging/postgres/PostgresMessenger.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/postgres/PostgresMessenger.java
@@ -150,7 +150,7 @@ public class PostgresMessenger implements Messenger {
                 }
 
             } catch (PSQLException e) {
-                if (!(e.getCause() instanceof SocketException && e.getCause().getMessage().equals("Socket closed"))) {
+                if (!(e.getCause() instanceof SocketException && "Socket closed".equals(e.getCause().getMessage()))) {
                     e.printStackTrace();
                 }
             } catch (Exception e) {


### PR DESCRIPTION
`e.getCause().getMessage()` can return `null` (as `Throwable#getMessage` is nullable). Calling `.equals(...)` on it throws a `NullPointerException`, which prevents the intended suppression of the "Socket closed" case.

Swapped the operands so the string literal is on the left side. `"Socket closed".equals(null)` safely returns `false` instead of throwing.