### PR TITLE
[fix] Add missing 'redis.ssl' and 'nats.ssl' options to config files

### DIFF
--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -268,6 +268,7 @@ redis:
   address: localhost
   username: ''
   password: ''
+  ssl: false
   # Settings for Redis Sentinel.
   # Sentinel provides high availability for Redis by monitoring master/replica instances.
   # Port 26379 is used by default for sentinel nodes.
@@ -287,6 +288,7 @@ nats:
   username: ''
   password: ''
   token: ''
+  ssl: false
 
 # Settings for RabbitMQ.
 # Port 5672 is used by default; set address to "host:port" if differs

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -266,6 +266,7 @@ redis:
   address: localhost
   username: ''
   password: ''
+  ssl: false
   # Settings for Redis Sentinel.
   # Sentinel provides high availability for Redis by monitoring master/replica instances.
   # Port 26379 is used by default for sentinel nodes.
@@ -285,6 +286,7 @@ nats:
   username: ''
   password: ''
   token: ''
+  ssl: false
 
 # Settings for RabbitMQ.
 # Port 5672 is used by default; set address to "host:port" if differs

--- a/fabric/src/main/resources/luckperms.conf
+++ b/fabric/src/main/resources/luckperms.conf
@@ -271,6 +271,7 @@ redis {
   address = "localhost"
   username = ""
   password = ""
+  ssl = false
   # Settings for Redis Sentinel.
   # Sentinel provides high availability for Redis by monitoring master/replica instances.
   # Port 26379 is used by default for sentinel nodes.
@@ -291,6 +292,7 @@ nats {
   username = ""
   password = ""
   token = ""
+  ssl = false
 }
 
 # Settings for RabbitMQ.

--- a/forge/src/main/resources/luckperms.conf
+++ b/forge/src/main/resources/luckperms.conf
@@ -269,6 +269,7 @@ redis {
   address = "localhost"
   username = ""
   password = ""
+  ssl = false
   # Settings for Redis Sentinel.
   # Sentinel provides high availability for Redis by monitoring master/replica instances.
   # Port 26379 is used by default for sentinel nodes.
@@ -289,6 +290,7 @@ nats {
   username = ""
   password = ""
   token = ""
+  ssl = false
 }
 
 # Settings for RabbitMQ.

--- a/hytale/src/main/resources/config.yml
+++ b/hytale/src/main/resources/config.yml
@@ -268,6 +268,7 @@ redis:
   address: localhost
   username: ''
   password: ''
+  ssl: false
 
 # Settings for Nats.
 # Port 4222 is used by default; set address to "host:port" if differs
@@ -277,6 +278,7 @@ nats:
   username: ''
   password: ''
   token: ''
+  ssl: false
 
 # Settings for RabbitMQ.
 # Port 5672 is used by default; set address to "host:port" if differs

--- a/neoforge/src/main/resources/luckperms.conf
+++ b/neoforge/src/main/resources/luckperms.conf
@@ -269,6 +269,7 @@ redis {
   address = "localhost"
   username = ""
   password = ""
+  ssl = false
   # Settings for Redis Sentinel.
   # Sentinel provides high availability for Redis by monitoring master/replica instances.
   # Port 26379 is used by default for sentinel nodes.
@@ -289,6 +290,7 @@ nats {
   username = ""
   password = ""
   token = ""
+  ssl = false
 }
 
 # Settings for RabbitMQ.

--- a/nukkit/src/main/resources/config.yml
+++ b/nukkit/src/main/resources/config.yml
@@ -263,6 +263,7 @@ redis:
   address: localhost
   username: ''
   password: ''
+  ssl: false
   # Settings for Redis Sentinel.
   # Sentinel provides high availability for Redis by monitoring master/replica instances.
   # Port 26379 is used by default for sentinel nodes.
@@ -282,6 +283,7 @@ nats:
   username: ''
   password: ''
   token: ''
+  ssl: false
 
 # Settings for RabbitMQ.
 # Port 5672 is used by default; set address to "host:port" if differs

--- a/sponge/src/main/resources/luckperms.conf
+++ b/sponge/src/main/resources/luckperms.conf
@@ -271,6 +271,7 @@ redis {
   address = "localhost"
   username = ""
   password = ""
+  ssl = false
   # Settings for Redis Sentinel.
   # Sentinel provides high availability for Redis by monitoring master/replica instances.
   # Port 26379 is used by default for sentinel nodes.
@@ -291,6 +292,7 @@ nats {
   username = ""
   password = ""
   token = ""
+  ssl = false
 }
 
 # Settings for RabbitMQ.

--- a/standalone/src/main/resources/config.yml
+++ b/standalone/src/main/resources/config.yml
@@ -253,6 +253,7 @@ redis:
   address: localhost
   username: ''
   password: ''
+  ssl: false
   # Settings for Redis Sentinel.
   # Sentinel provides high availability for Redis by monitoring master/replica instances.
   # Port 26379 is used by default for sentinel nodes.
@@ -272,6 +273,7 @@ nats:
   username: ''
   password: ''
   token: ''
+  ssl: false
 
 # Settings for RabbitMQ.
 # Port 5672 is used by default; set address to "host:port" if differs

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -257,6 +257,7 @@ redis:
   address: localhost
   username: ''
   password: ''
+  ssl: false
   # Settings for Redis Sentinel.
   # Sentinel provides high availability for Redis by monitoring master/replica instances.
   # Port 26379 is used by default for sentinel nodes.
@@ -276,6 +277,7 @@ nats:
   username: ''
   password: ''
   token: ''
+  ssl: false
 
 # Settings for RabbitMQ.
 # Port 5672 is used by default; set address to "host:port" if differs


### PR DESCRIPTION
I noticed that these options where missing from the config even though they exists in the code after struggling to get TLS to work for longer than I'd like to admit. Just figured I would make sure everyone else can find it too.