### PR TITLE
Add configurable keepalive for the Redis pub/sub connection

### DIFF
--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -268,6 +268,9 @@ redis:
   address: localhost
   username: ''
   password: ''
+  # How often (in milliseconds) a ping should be sent on the pub/sub connection to keep it alive.
+  # This prevents idle connections from being closed by firewalls or proxies. Set to 0 to disable.
+  keepalive-interval: 60000
   # Settings for Redis Sentinel.
   # Sentinel provides high availability for Redis by monitoring master/replica instances.
   # Port 26379 is used by default for sentinel nodes.

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -266,6 +266,9 @@ redis:
   address: localhost
   username: ''
   password: ''
+  # How often (in milliseconds) a ping should be sent on the pub/sub connection to keep it alive.
+  # This prevents idle connections from being closed by firewalls or proxies. Set to 0 to disable.
+  keepalive-interval: 60000
   # Settings for Redis Sentinel.
   # Sentinel provides high availability for Redis by monitoring master/replica instances.
   # Port 26379 is used by default for sentinel nodes.

--- a/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
@@ -706,6 +706,11 @@ public final class ConfigKeys {
     public static final ConfigKey<Boolean> REDIS_SSL = notReloadable(booleanKey("redis.ssl", false));
 
     /**
+     * How often, in milliseconds, a ping should be sent on the redis pub/sub connection to keep it alive
+     */
+    public static final ConfigKey<Integer> REDIS_KEEPALIVE_INTERVAL = notReloadable(key(c -> c.getInteger("redis.keepalive-interval", 60000)));
+
+    /**
      * If redis sentinel is enabled
      */
     public static final ConfigKey<Boolean> REDIS_SENTINEL_ENABLED = notReloadable(booleanKey("redis.sentinel.enabled", false));

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
@@ -196,9 +196,10 @@ public class MessagingFactory<P extends LuckPermsPlugin> {
 
         @Override
         public @NonNull Messenger obtain(@NonNull IncomingMessageConsumer incomingMessageConsumer) {
-            RedisMessenger redis = new RedisMessenger(getPlugin(), incomingMessageConsumer);
-
             LuckPermsConfiguration config = getPlugin().getConfiguration();
+
+            RedisMessenger redis = new RedisMessenger(getPlugin(), incomingMessageConsumer, config.get(ConfigKeys.REDIS_KEEPALIVE_INTERVAL));
+
             String address = config.get(ConfigKeys.REDIS_ADDRESS);
             List<String> addresses = config.get(ConfigKeys.REDIS_ADDRESSES);
             String username = config.get(ConfigKeys.REDIS_USERNAME);

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/redis/RedisMessenger.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/redis/RedisMessenger.java
@@ -26,6 +26,7 @@
 package me.lucko.luckperms.common.messaging.redis;
 
 import me.lucko.luckperms.common.plugin.LuckPermsPlugin;
+import me.lucko.luckperms.common.plugin.scheduler.SchedulerTask;
 import net.luckperms.api.messenger.IncomingMessageConsumer;
 import net.luckperms.api.messenger.Messenger;
 import net.luckperms.api.messenger.message.OutgoingMessage;
@@ -42,6 +43,7 @@ import redis.clients.jedis.UnifiedJedis;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -53,14 +55,17 @@ public class RedisMessenger implements Messenger {
 
     private final LuckPermsPlugin plugin;
     private final IncomingMessageConsumer consumer;
+    private final long keepaliveInterval;
 
     private /* final */ UnifiedJedis jedis;
     private /* final */ Subscription sub;
+    private SchedulerTask keepaliveTask;
     private boolean closing = false;
 
-    public RedisMessenger(LuckPermsPlugin plugin, IncomingMessageConsumer consumer) {
+    public RedisMessenger(LuckPermsPlugin plugin, IncomingMessageConsumer consumer, long keepaliveInterval) {
         this.plugin = plugin;
         this.consumer = consumer;
+        this.keepaliveInterval = keepaliveInterval;
     }
 
     public void init(List<String> addresses, String username, String password, boolean ssl) {
@@ -83,6 +88,10 @@ public class RedisMessenger implements Messenger {
         this.jedis = jedis;
         this.sub = new Subscription(this);
         this.plugin.getBootstrap().getScheduler().executeAsync(this.sub);
+
+        if (this.keepaliveInterval > 0) {
+            this.keepaliveTask = this.plugin.getBootstrap().getScheduler().asyncRepeating(this.sub::sendKeepalive, this.keepaliveInterval, TimeUnit.MILLISECONDS);
+        }
     }
 
     private static JedisClientConfig jedisConfig(String username, String password, boolean ssl) {
@@ -115,6 +124,10 @@ public class RedisMessenger implements Messenger {
     @Override
     public void close() {
         this.closing = true;
+        if (this.keepaliveTask != null) {
+            this.keepaliveTask.cancel();
+            this.keepaliveTask = null;
+        }
         this.sub.unsubscribe();
         this.jedis.close();
     }
@@ -166,6 +179,18 @@ public class RedisMessenger implements Messenger {
                 return;
             }
             this.messenger.consumer.consumeIncomingMessageAsString(msg);
+        }
+
+        private void sendKeepalive() {
+            if (this.messenger.closing || !isSubscribed()) {
+                return;
+            }
+
+            try {
+                ping();
+            } catch (Exception e) {
+                this.messenger.plugin.getLogger().warn("Error whilst pinging the redis pubsub connection", e);
+            }
         }
 
         private boolean isRedisAlive() {

--- a/fabric/src/main/resources/luckperms.conf
+++ b/fabric/src/main/resources/luckperms.conf
@@ -271,6 +271,9 @@ redis {
   address = "localhost"
   username = ""
   password = ""
+  # How often (in milliseconds) a ping should be sent on the pub/sub connection to keep it alive.
+  # This prevents idle connections from being closed by firewalls or proxies. Set to 0 to disable.
+  keepalive-interval = 60000
   # Settings for Redis Sentinel.
   # Sentinel provides high availability for Redis by monitoring master/replica instances.
   # Port 26379 is used by default for sentinel nodes.

--- a/forge/src/main/resources/luckperms.conf
+++ b/forge/src/main/resources/luckperms.conf
@@ -269,6 +269,9 @@ redis {
   address = "localhost"
   username = ""
   password = ""
+  # How often (in milliseconds) a ping should be sent on the pub/sub connection to keep it alive.
+  # This prevents idle connections from being closed by firewalls or proxies. Set to 0 to disable.
+  keepalive-interval = 60000
   # Settings for Redis Sentinel.
   # Sentinel provides high availability for Redis by monitoring master/replica instances.
   # Port 26379 is used by default for sentinel nodes.

--- a/hytale/src/main/resources/config.yml
+++ b/hytale/src/main/resources/config.yml
@@ -268,6 +268,9 @@ redis:
   address: localhost
   username: ''
   password: ''
+  # How often (in milliseconds) a ping should be sent on the pub/sub connection to keep it alive.
+  # This prevents idle connections from being closed by firewalls or proxies. Set to 0 to disable.
+  keepalive-interval: 60000
 
 # Settings for Nats.
 # Port 4222 is used by default; set address to "host:port" if differs

--- a/neoforge/src/main/resources/luckperms.conf
+++ b/neoforge/src/main/resources/luckperms.conf
@@ -269,6 +269,9 @@ redis {
   address = "localhost"
   username = ""
   password = ""
+  # How often (in milliseconds) a ping should be sent on the pub/sub connection to keep it alive.
+  # This prevents idle connections from being closed by firewalls or proxies. Set to 0 to disable.
+  keepalive-interval = 60000
   # Settings for Redis Sentinel.
   # Sentinel provides high availability for Redis by monitoring master/replica instances.
   # Port 26379 is used by default for sentinel nodes.

--- a/nukkit/src/main/resources/config.yml
+++ b/nukkit/src/main/resources/config.yml
@@ -263,6 +263,9 @@ redis:
   address: localhost
   username: ''
   password: ''
+  # How often (in milliseconds) a ping should be sent on the pub/sub connection to keep it alive.
+  # This prevents idle connections from being closed by firewalls or proxies. Set to 0 to disable.
+  keepalive-interval: 60000
   # Settings for Redis Sentinel.
   # Sentinel provides high availability for Redis by monitoring master/replica instances.
   # Port 26379 is used by default for sentinel nodes.

--- a/sponge/src/main/resources/luckperms.conf
+++ b/sponge/src/main/resources/luckperms.conf
@@ -271,6 +271,9 @@ redis {
   address = "localhost"
   username = ""
   password = ""
+  # How often (in milliseconds) a ping should be sent on the pub/sub connection to keep it alive.
+  # This prevents idle connections from being closed by firewalls or proxies. Set to 0 to disable.
+  keepalive-interval = 60000
   # Settings for Redis Sentinel.
   # Sentinel provides high availability for Redis by monitoring master/replica instances.
   # Port 26379 is used by default for sentinel nodes.

--- a/standalone/src/main/resources/config.yml
+++ b/standalone/src/main/resources/config.yml
@@ -253,6 +253,9 @@ redis:
   address: localhost
   username: ''
   password: ''
+  # How often (in milliseconds) a ping should be sent on the pub/sub connection to keep it alive.
+  # This prevents idle connections from being closed by firewalls or proxies. Set to 0 to disable.
+  keepalive-interval: 60000
   # Settings for Redis Sentinel.
   # Sentinel provides high availability for Redis by monitoring master/replica instances.
   # Port 26379 is used by default for sentinel nodes.

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -257,6 +257,9 @@ redis:
   address: localhost
   username: ''
   password: ''
+  # How often (in milliseconds) a ping should be sent on the pub/sub connection to keep it alive.
+  # This prevents idle connections from being closed by firewalls or proxies. Set to 0 to disable.
+  keepalive-interval: 60000
   # Settings for Redis Sentinel.
   # Sentinel provides high availability for Redis by monitoring master/replica instances.
   # Port 26379 is used by default for sentinel nodes.


### PR DESCRIPTION
fixes #4303

### Problem

The Redis messaging subscriber is completely idle at the application level while blocked in the pub/sub `subscribe(...)` call. Stateful network infrastructure (firewalls, NAT gateways, cloud load balancers) closes the connection once its idle timeout elapses - the reporter in #4303 sees this consistently at 3600s. TCP-level `tcp-keepalive` on the Redis side does not prevent it.

Because pub/sub is at-most-once with no replay, every update published between the silent drop and the next reconnect is lost. The affected server keeps running with stale permission data.

### Change

Periodically send a `PING` on the pub/sub connection itself via `JedisPubSub#ping`, which sends and flushes the command without reading a reply - the pong is consumed by the already-blocked `subscribe(...)` reader through `onPong`. No extra pooled connection is used.

The interval is exposed as a new `redis.keepalive-interval` option, in milliseconds, `0` to disable:

```yaml
redis:
  enabled: false
  address: localhost
  username: ''
  password: ''
  # How often (in milliseconds) a ping should be sent on the pub/sub connection to keep it alive.
  # This prevents idle connections from being closed by firewalls or proxies. Set to 0 to disable.
  keepalive-interval: 60000
```

The task is scheduled with `SchedulerAdapter#asyncRepeating`, skips when the messenger is closing or not currently subscribed, and is cancelled in `close()`. A failed ping is logged as a warning; reconnection is still handled by the existing loop in `Subscription#run`.

Applies to all three connection modes (pooled, cluster, sentinel), since it hooks the shared `Subscription` rather than any particular client type.

## Note that those changes were more or less fully generated with claude.