### PR TITLE
fix: enforce disabled vanilla operator status

### DIFF
--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -10,11 +10,22 @@ java {
     disableAutoTargetJvm()
 }
 
+test {
+    useJUnitPlatform()
+}
+
 dependencies {
     implementation project(':common')
     compileOnly project(':common:loader-utils')
+    testRuntimeOnly project(':common:loader-utils')
+
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.0'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.mockito:mockito-core:5.18.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.18.0'
 
     compileOnly 'dev.folia:folia-api:26.1.2.build.8-stable'
+    testRuntimeOnly 'dev.folia:folia-api:26.1.2.build.8-stable'
     compileOnly('net.kyori:adventure-platform-bukkit:4.4.0') {
         exclude(module: 'adventure-bom')
         exclude(module: 'adventure-api')

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/inject/permissible/LuckPermsPermissible.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/inject/permissible/LuckPermsPermissible.java
@@ -294,9 +294,13 @@ public class LuckPermsPermissible extends PermissibleBase {
         // (#invalidate is a fast call)
         if (this.queryOptionsSupplier != null) { // this method is called by the super class constructor, before this class has fully initialised
             this.queryOptionsSupplier.invalidateCache();
-        }
 
-        // but we don't need to do anything else in this method, unlike the CB impl.
+            if (!this.plugin.getConfiguration().get(ConfigKeys.OPS_ENABLED) &&
+                    !this.plugin.getConfiguration().get(ConfigKeys.AUTO_OP) &&
+                    this.player.isOp()) {
+                this.player.setOp(false);
+            }
+        }
     }
 
     @Override

--- a/bukkit/src/test/java/me/lucko/luckperms/bukkit/inject/permissible/LuckPermsPermissibleTest.java
+++ b/bukkit/src/test/java/me/lucko/luckperms/bukkit/inject/permissible/LuckPermsPermissibleTest.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of LuckPerms, licensed under the MIT License.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+package me.lucko.luckperms.bukkit.inject.permissible;
+
+import me.lucko.luckperms.bukkit.LPBukkitPlugin;
+import me.lucko.luckperms.bukkit.context.BukkitContextManager;
+import me.lucko.luckperms.common.config.ConfigKeys;
+import me.lucko.luckperms.common.config.LuckPermsConfiguration;
+import me.lucko.luckperms.common.context.manager.QueryOptionsSupplier;
+import me.lucko.luckperms.common.model.User;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class LuckPermsPermissibleTest {
+
+    @Mock private Player player;
+    @Mock private User user;
+    @Mock private LPBukkitPlugin plugin;
+    @Mock private BukkitContextManager contextManager;
+    @Mock private QueryOptionsSupplier queryOptionsSupplier;
+    @Mock private LuckPermsConfiguration configuration;
+
+    @BeforeEach
+    public void setupMocks() {
+        when(this.plugin.getContextManager()).thenReturn(this.contextManager);
+        when(this.contextManager.createQueryOptionsSupplier(this.player)).thenReturn(this.queryOptionsSupplier);
+        when(this.plugin.getConfiguration()).thenReturn(this.configuration);
+    }
+
+    @Test
+    public void testRecalculatePermissionsRevokesDisabledOperator() {
+        LuckPermsPermissible permissible = createPermissible(false, false, true);
+
+        permissible.recalculatePermissions();
+
+        verify(this.queryOptionsSupplier).invalidateCache();
+        verify(this.player).setOp(false);
+    }
+
+    @Test
+    public void testRecalculatePermissionsKeepsEnabledOperator() {
+        LuckPermsPermissible permissible = createPermissible(true, false, true);
+
+        permissible.recalculatePermissions();
+
+        verify(this.queryOptionsSupplier).invalidateCache();
+        verify(this.player, never()).setOp(anyBoolean());
+    }
+
+    @Test
+    public void testRecalculatePermissionsKeepsAutoOperator() {
+        LuckPermsPermissible permissible = createPermissible(false, true, true);
+
+        permissible.recalculatePermissions();
+
+        verify(this.queryOptionsSupplier).invalidateCache();
+        verify(this.player, never()).setOp(anyBoolean());
+    }
+
+    @Test
+    public void testRecalculatePermissionsDoesNotUpdateNonOperator() {
+        LuckPermsPermissible permissible = createPermissible(false, false, false);
+
+        permissible.recalculatePermissions();
+
+        verify(this.queryOptionsSupplier).invalidateCache();
+        verify(this.player, never()).setOp(anyBoolean());
+    }
+
+    private LuckPermsPermissible createPermissible(boolean opsEnabled, boolean autoOp, boolean op) {
+        lenient().when(this.configuration.get(ConfigKeys.OPS_ENABLED)).thenReturn(opsEnabled);
+        lenient().when(this.configuration.get(ConfigKeys.AUTO_OP)).thenReturn(autoOp);
+        lenient().when(this.player.isOp()).thenReturn(op);
+        return new LuckPermsPermissible(this.player, this.user, this.plugin);
+    }
+
+}


### PR DESCRIPTION
Enforce the disabled-OP invariant in `LuckPermsPermissible.recalculatePermissions`, the existing production hook documented as running when a player's OP status changes, instead of adding brittle `/execute` parsing or periodic player scans. When Bukkit's `enable-ops` setting is false, LuckPerms removes existing operators at startup and blocks direct `op`/`deop` command events.

With `enable-ops: false`, `auto-op: false`, and a player whose OP state has just become true, recalculating permissions calls `setOp(false)` and leaves the player non-op, covering grants made through `/execute` or any other Bukkit path; With normal operators enabled, recalculating an opped player does not revoke OP status.

Closes #4290
