### PR TITLE
Replace Identifiers path separator with Luckperms separator

### DIFF
--- a/fabric/src/main/java/me/lucko/luckperms/fabric/listeners/FabricPermissionsApiV1Listener.java
+++ b/fabric/src/main/java/me/lucko/luckperms/fabric/listeners/FabricPermissionsApiV1Listener.java
@@ -70,7 +70,7 @@ public class FabricPermissionsApiV1Listener {
 
         if (codec == Codec.BOOL) {
             // permission check
-            String permissionString = node.key().getNamespace() + '.' + node.key().getPath();
+            String permissionString = node.key().getNamespace() + '.' + node.key().getPath().replace('/', '.');
             Boolean permissionValue = permissionCheck(ctx, permissionString);
             return node.cast(permissionValue);
         }

--- a/fabric/src/main/java/me/lucko/luckperms/fabric/listeners/FabricPermissionsListener.java
+++ b/fabric/src/main/java/me/lucko/luckperms/fabric/listeners/FabricPermissionsListener.java
@@ -64,7 +64,7 @@ public class FabricPermissionsListener {
         public boolean hasPermission(@NonNull Permission permission) {
             if (permission instanceof Permission.Atom) {
                 Identifier permissionId = ((Permission.Atom) permission).id();
-                String permissionString = permissionId.getNamespace() + '.' + permissionId.getPath();
+                String permissionString = permissionId.getNamespace() + '.' + permissionId.getPath().replace('/', '.');
 
                 Tristate result = ((MixinUser) this.player).luckperms$hasPermission(permissionString);
                 if (result != Tristate.UNDEFINED) {


### PR DESCRIPTION
Fabric permission api v1 recommends permission id's like this: `Identifier.fromNamespaceAndPath("mymod", "command/main")`. These paths don't work well with luckperms permission id system and should therefor use luckperms `.` path separator instead.