### PR TITLE
chore: update to latest hytale version

### DIFF
--- a/hytale/gradle.properties
+++ b/hytale/gradle.properties
@@ -1,1 +1,1 @@
-hytaleVersion=0.5.2
+hytaleVersion=0.6.0-pre.13.1

--- a/hytale/src/main/java/me/lucko/luckperms/hytale/HytaleCommandManager.java
+++ b/hytale/src/main/java/me/lucko/luckperms/hytale/HytaleCommandManager.java
@@ -92,11 +92,6 @@ public class HytaleCommandManager extends CommandManager {
         }
 
         @Override
-        protected boolean canGeneratePermission() {
-            return false;
-        }
-
-        @Override
         public boolean hasPermission(@NonNull CommandSender sender) {
             return HytaleCommandManager.this.hasPermissionForAny(sender);
         }

--- a/hytale/src/main/java/me/lucko/luckperms/hytale/service/LuckPermsPermissionProvider.java
+++ b/hytale/src/main/java/me/lucko/luckperms/hytale/service/LuckPermsPermissionProvider.java
@@ -195,6 +195,13 @@ public class LuckPermsPermissionProvider implements PermissionProvider {
                 : Set.of();
     }
 
+    @Override
+    public @NonNull Set<UUID> getUsersWithPermission(@NonNull String permission) {
+        return this.delegateToHytaleProvider
+                ? this.hytaleProvider.getUsersWithPermission(permission)
+                : Set.of();
+    }
+
     /**
      * A permissions set that tricks {@link PermissionsModule#hasPermission(Set, String)} into always
      * returning according to LuckPerms data.


### PR DESCRIPTION
Updates the hytale module to the latest pre-release which will be the same version as tomorrow's Update 6 release. There will be no api changes tomorrow on release vs what is current published under 0.6.0-pre.13.1